### PR TITLE
test: add concretely typed tests

### DIFF
--- a/test/test_code_quality.jl
+++ b/test/test_code_quality.jl
@@ -31,6 +31,48 @@ if isempty(VERSION.prerelease)
 end
 
 @testset "Concretely typed" begin
-    using SecondQuantizedAlgebra
+    import SecondQuantizedAlgebra as SQA
     using CheckConcreteStructs
+
+    all_concrete(SQA.QMul)
+    all_concrete(SQA.QAdd)
+
+    all_concrete(SQA.AvgSym)
+
+    all_concrete(SQA.Parameter)
+    all_concrete(SQA.RealParameter)
+
+    all_concrete(SQA.FockSpace)
+    all_concrete(SQA.Destroy)
+    all_concrete(SQA.Create)
+
+    all_concrete(SQA.PauliSpace)
+    all_concrete(SQA.Pauli)
+    all_concrete(SQA.SpinSpace)
+    all_concrete(SQA.Spin)
+
+    all_concrete(SQA.NLevelSpace)
+    all_concrete(SQA.Transition)
+    all_concrete(SQA.CallableTransition)
+
+    all_concrete(SQA.ProductSpace)
+    all_concrete(SQA.ClusterSpace)
+    all_concrete(SQA.ClusterAon)
+
+    all_concrete(SQA.IndexedAverageSum)
+    all_concrete(SQA.IndexedAverageDoubleSum)
+    all_concrete(SQA.SingleNumberedVariable)
+    all_concrete(SQA.DoubleNumberedVariable)
+    all_concrete(SQA.SpecialIndexedAverage)
+
+    all_concrete(SQA.DoubleSum)
+
+    all_concrete(SQA.NumberedOperator)
+
+    all_concrete(SQA.Index)
+    all_concrete(SQA.IndexedVariable)
+    all_concrete(SQA.DoubleIndexedVariable)
+    all_concrete(SQA.IndexedOperator)
+    all_concrete(SQA.SingleSum)
+    all_concrete(SQA.SpecialIndexedTerm)
 end


### PR DESCRIPTION
```julia
┌ Warning: AbstractFieldError in struct `QMul`: field `arg_c` with declared type `Any` is not concretely typed.
└ @ CheckConcreteStructs ~/.julia/packages/CheckConcreteStructs/CmAzf/src/CheckConcreteStructs.jl:209
┌ Warning: AbstractFieldError in struct `IndexedAverageSum`: field `term` with declared type `Union{var"#s123", var"#s122"} where {var"#s123"<:(SymbolicUtils.BasicSymbolic{<:SecondQuantizedAlgebra.AvgSym}), var"#s122"<:(SymbolicUtils.BasicSymbolic{<:CNumber})}` is not concretely typed.
└ @ CheckConcreteStructs ~/.julia/packages/CheckConcreteStructs/CmAzf/src/CheckConcreteStructs.jl:209
┌ Warning: AbstractFieldError in struct `IndexedAverageSum`: field `metadata` with declared type `Any` is not concretely typed.
└ @ CheckConcreteStructs ~/.julia/packages/CheckConcreteStructs/CmAzf/src/CheckConcreteStructs.jl:209
┌ Warning: AbstractFieldError in struct `DoubleNumberedVariable`: field `numb1` with declared type `Union{var"#s123", var"#s122"} where {var"#s123"<:Index, var"#s122"<:Int64}` is not concretely typed.
└ @ CheckConcreteStructs ~/.julia/packages/CheckConcreteStructs/CmAzf/src/CheckConcreteStructs.jl:209
┌ Warning: AbstractFieldError in struct `DoubleNumberedVariable`: field `numb2` with declared type `Union{var"#s123", var"#s122"} where {var"#s123"<:Index, var"#s122"<:Int64}` is not concretely typed.
└ @ CheckConcreteStructs ~/.julia/packages/CheckConcreteStructs/CmAzf/src/CheckConcreteStructs.jl:209
┌ Warning: AbstractFieldError in struct `SpecialIndexedAverage`: field `term` with declared type `Union{var"#s123", var"#s122"} where {var"#s123"<:(SymbolicUtils.BasicSymbolic{<:SecondQuantizedAlgebra.AvgSym}), var"#s122"<:(SymbolicUtils.BasicSymbolic{<:CNumber})}` is not concretely typed.
└ @ CheckConcreteStructs ~/.julia/packages/CheckConcreteStructs/CmAzf/src/CheckConcreteStructs.jl:209
┌ Warning: AbstractFieldError in struct `DoubleSum`: field `innerSum` with declared type `SingleSum` is not concretely typed.
└ @ CheckConcreteStructs ~/.julia/packages/CheckConcreteStructs/CmAzf/src/CheckConcreteStructs.jl:209
┌ Warning: AbstractFieldError in struct `NumberedOperator`: field `op` with declared type `Union{Create, Destroy, Transition}` is not concretely typed.
└ @ CheckConcreteStructs ~/.julia/packages/CheckConcreteStructs/CmAzf/src/CheckConcreteStructs.jl:209
┌ Warning: AbstractFieldError in struct `Index`: field `hilb` with declared type `HilbertSpace` is not concretely typed.
└ @ CheckConcreteStructs ~/.julia/packages/CheckConcreteStructs/CmAzf/src/CheckConcreteStructs.jl:209
┌ Warning: AbstractFieldError in struct `Index`: field `range` with declared type `Union{var"#s123", var"#s122", var"#s121", var"#s120", var"#s119"} where {var"#s123"<:SymbolicUtils.Sym, var"#s122"<:Number, var"#s121"<:SymbolicUtils.Mul, var"#s120"<:SymbolicUtils.Div, var"#s119"<:SymbolicUtils.BasicSymbolic}` is not concretely typed.
└ @ CheckConcreteStructs ~/.julia/packages/CheckConcreteStructs/CmAzf/src/CheckConcreteStructs.jl:209
┌ Warning: AbstractFieldError in struct `IndexedOperator`: field `op` with declared type `Union{Create, Destroy, Transition}` is not concretely typed.
└ @ CheckConcreteStructs ~/.julia/packages/CheckConcreteStructs/CmAzf/src/CheckConcreteStructs.jl:209
┌ Warning: AbstractFieldError in struct `SingleSum`: field `term` with declared type `Union{var"#s123", var"#s122", var"#s121", var"#s120", var"#s119"} where {var"#s123"<:SecondQuantizedAlgebra.QNumber, var"#s122"<:CNumber, var"#s121"<:SymbolicUtils.BasicSymbolic{IndexedVariable}, var"#s120"<:SymbolicUtils.BasicSymbolic{DoubleIndexedVariable}, var"#s119"<:SymbolicUtils.BasicSymbolic{CNumber}}` is not concretely typed.
└ @ CheckConcreteStructs ~/.julia/packages/CheckConcreteStructs/CmAzf/src/CheckConcreteStructs.jl:209
┌ Warning: AbstractFieldError in struct `SpecialIndexedTerm`: field `term` with declared type `Union{var"#s123", var"#s122", var"#s121", var"#s120", var"#s119"} where {var"#s123"<:SecondQuantizedAlgebra.QNumber, var"#s122"<:CNumber, var"#s121"<:SymbolicUtils.BasicSymbolic{IndexedVariable}, var"#s120"<:SymbolicUtils.BasicSymbolic{DoubleIndexedVariable}, var"#s119"<:SymbolicUtils.BasicSymbolic{CNumber}}` is not concretely typed.
└ @ CheckConcreteStructs ~/.julia/packages/CheckConcreteStructs/CmAzf/src/CheckConcreteStructs.jl:209
```