### PR TITLE
Add CollectiveTransition for symmetric-subspace collective atoms

### DIFF
--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -3,6 +3,7 @@ pages = [
     "Implementation" => "implementation.md",
     "Ordering Conventions" => "ordering.md",
     "Symbolic Sums and Indices" => "symbolic_sums.md",
+    "Collective Atoms" => "collective.md",
     "Examples" => [
         "Schrieffer-Wolff Transformation" => "examples/schrieffer_wolff.md",
     ],

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -81,6 +81,10 @@ Transition
 ```
 
 ```@docs
+CollectiveTransition
+```
+
+```@docs
 Pauli
 ```
 

--- a/docs/src/collective.md
+++ b/docs/src/collective.md
@@ -2,19 +2,30 @@
 CurrentModule = SecondQuantizedAlgebra
 ```
 
-# Collective Atoms — Two Regimes
+# Collective Atoms — Two Computational Approaches
 
-A system of `N` atoms can be modeled in two qualitatively different ways depending on whether the atoms are *individually addressable*. SecondQuantizedAlgebra.jl supports both — pick the one that matches your physics, and don't mix them within the same atomic Hilbert space.
+A system of `N` identical atoms in collective dynamics — Dicke models, superradiance, Tavis–Cummings — can be tackled in two complementary ways. Both describe the same physics; they differ in the *computational strategy* and the kind of result you get out at the end.
 
-## Distinguishable atoms — indexed `Σ`
+| | Indexed `Σ` (cumulant approach) | [`CollectiveTransition`](@ref) (exact symmetric subspace) |
+|---|---|---|
+| Numerical strategy | Cumulant / mean-field truncation | Exact diagonalization on `ManyBodyBasis` |
+| Hilbert space at numeric layer | Single representative atom + symbolic site index | Full symmetric subspace, dim ``\binom{N+n-1}{n-1}`` |
+| Site-dependent parameters (e.g. ``g_i``) | Yes, via [`IndexedVariable`](@ref) | No (atoms identical by construction) |
+| `N` scaling | Large `N` (truncation order chosen at solve time) | Modest `N` (``\le`` thousands for two-level atoms) |
+| Output | Mean-field / cumulant equations of motion | State vector or density matrix on the symmetric subspace |
+| Algebra at the symbolic level | Per-atom transition rules + diagonal split + completeness | Closed ``\mathfrak{su}(N)`` Lie algebra |
 
-Use this when atoms have site-resolved properties: position-dependent couplings ``g_i``, individual addressing, disorder, etc. Each atom lives in its own copy of an [`NLevelSpace`](@ref). Symbolic sums over a site index keep the bookkeeping compact at the algebra level.
+Pick the one that matches your computational strategy, and don't mix them on the same `NLevelSpace`.
+
+## Cumulant approach — indexed `Σ`
+
+Use this when you want **mean-field-style equations of motion** and `N` is large enough that exact simulation is infeasible. Atoms can carry site-dependent symbolic parameters via [`IndexedVariable`](@ref). The cumulant truncation order is supplied to the downstream solver — the algebra layer keeps `N` symbolic.
 
 ```julia
 using SecondQuantizedAlgebra
 @variables N
 
-ha = NLevelSpace(:atom, 2)
+ha = NLevelSpace(:atom, 2)          # single representative atom
 hc = FockSpace(:cavity)
 h  = hc ⊗ ha
 
@@ -26,19 +37,17 @@ gi = IndexedVariable(:g, i)
 H_TC = Σ(gi * (a' * σ(1, 2) + a * σ(2, 1)), i)
 ```
 
-The full Hilbert space is ``\dim(\mathcal{H}_{\text{atom}})^{N}`` — exponential in `N`. Numeric simulation is tractable only for small `N` (typically `N ≲ 10` for `n=2` levels). The diagonal-split machinery, completeness, and per-atom σᵍᵍ rewriting are documented in [Symbolic Sums and Indices](@ref) and [Ordering Conventions](@ref).
+Heisenberg equations follow from `commutator(H, op)`; the diagonal-split and completeness machinery handles the per-atom algebra correctly. See [Symbolic Sums and Indices](@ref) for the full set of rules.
 
-## Indistinguishable atoms — `CollectiveTransition`
+## Exact symmetric subspace — `CollectiveTransition`
 
-Use this when the dynamics preserves permutation symmetry: Dicke physics, single-mode driving with no atom-resolved coupling, superradiance with identical atoms, etc. The state stays in the *symmetric (bosonic) subspace*, whose dimension is polynomial in `N`:
+Use this when you want **exact dynamics in the symmetric subspace** and `N` is small enough that the polynomial-size basis is tractable. Atoms are identical by construction (no site labels); the operator algebra is the closed ``\mathfrak{su}(N)`` Lie algebra; numeric simulation goes through `QuantumOpticsBase.ManyBodyBasis`.
 
 ```math
 \dim \mathcal{H}_\text{sym} = \binom{N + n - 1}{n - 1}
 ```
 
-For `N = 100` atoms with `n = 3` levels: full Hilbert space ``\sim 10^{47}``, symmetric subspace ``5151``. The latter is the only thing you can actually simulate.
-
-[`CollectiveTransition`](@ref) ``S^{ij} = \sum_k \sigma_k^{ij}`` is the operator on this subspace:
+For `N = 100` atoms with `n = 3` levels: full product space ``\sim 10^{47}`` (intractable), symmetric subspace ``5151`` (very tractable).
 
 ```julia
 h = NLevelSpace(:atom, 3)
@@ -47,11 +56,11 @@ S(i, j) = CollectiveTransition(h, :S, i, j)
 S(1, 2) * S(2, 3)         # eagerly normal-ordered: S(1, 3) + S(2, 3) * S(1, 2)
 ```
 
-These satisfy the ``\mathfrak{su}(N)`` Lie algebra ``[S^{ij}, S^{kl}] = \delta_{jk} S^{il} - \delta_{li} S^{kj}``, and the swap rule fires eagerly under [`NormalOrder`](@ref) so derivations stay in the closed collective form.
+The collective operators satisfy ``[S^{ij}, S^{kl}] = \delta_{jk} S^{il} - \delta_{li} S^{kj}``, and the swap rule fires eagerly under [`NormalOrder`](@ref) so derivations stay in the closed collective form rather than expanding into per-atom sums.
 
 ### Numeric conversion
 
-Numeric simulation requires a `QuantumOpticsBase.ManyBodyBasis` over the single-atom basis with `bosonstates`:
+Build a `ManyBodyBasis` over the single-atom basis with `bosonstates`:
 
 ```julia
 using QuantumOpticsBase
@@ -64,18 +73,7 @@ to_numeric(S(1, 2), b)   # many-body operator on the symmetric subspace
 
 The number of atoms `N` enters only here, not at the algebra layer.
 
-## Comparison
+### What the algebra does *not* do
 
-| | Distinguishable atoms | Indistinguishable atoms |
-|---|---|---|
-| Representation | [`Σ`](@ref) of [`IndexedOperator`](@ref) on a [`ProductSpace`](@ref) | [`CollectiveTransition`](@ref) on a single [`NLevelSpace`](@ref) |
-| Atoms | individually addressable | symmetric subspace, no atom labels |
-| Hilbert-space dim | ``n^N`` | ``\binom{N+n-1}{n-1}`` |
-| Numeric scaling | exponential in `N` | polynomial in `N` |
-| Algebra | per-atom Transition rules + diagonal split | ``\mathfrak{su}(N)`` Lie algebra (closed) |
-| Ground-state completeness | applies (``\sigma^{gg} = 1 - \sum_{k \neq g}\sigma^{kk}``) | does not apply (``\sum_j S^{jj} = N \cdot I``, deferred to numeric layer) |
-| Typical use case | Tavis–Cummings with disorder, lattice models, individual addressing | Dicke model, superradiant laser with identical atoms |
-
-## Don't mix
-
-[`Transition`](@ref) and [`CollectiveTransition`](@ref) on the *same* [`NLevelSpace`](@ref) are physically incompatible representations — pick one regime per atomic subspace. The package will not throw if you write `Transition(h, :σ, 1, 2) * CollectiveTransition(h, :S, 2, 1)`, but the result is meaningless: `Transition` lives in the full Hilbert space and `CollectiveTransition` in the symmetric subspace, and there is no canonical embedding between them at the algebra level.
+- **Single-atom completeness is not applied** to collective operators. Per-atom completeness ``\sigma^{gg} = 1 - \sum_{k \neq g}\sigma^{kk}`` does not hold for ``S^{gg}``: collectively, ``\sum_j S^{jj} = N \cdot I``. Since `N` lives at the numeric layer, the rewrite is deferred to it. This is why `simplify(expr, h)` does *not* expand ``S^{gg}`` even though it expands ``\sigma^{gg}``.
+- **No mixing with [`Transition`](@ref) on the same `NLevelSpace`.** `Transition` is a per-atom operator (the "single representative atom" of the cumulant approach); `CollectiveTransition` is a sum-over-atoms operator on the symmetric subspace. These live in different conceptual spaces, and the package will not throw if you write `Transition(h, :σ, 1, 2) * CollectiveTransition(h, :S, 2, 1)`, but the result is meaningless.

--- a/docs/src/collective.md
+++ b/docs/src/collective.md
@@ -1,0 +1,81 @@
+```@meta
+CurrentModule = SecondQuantizedAlgebra
+```
+
+# Collective Atoms — Two Regimes
+
+A system of `N` atoms can be modeled in two qualitatively different ways depending on whether the atoms are *individually addressable*. SecondQuantizedAlgebra.jl supports both — pick the one that matches your physics, and don't mix them within the same atomic Hilbert space.
+
+## Distinguishable atoms — indexed `Σ`
+
+Use this when atoms have site-resolved properties: position-dependent couplings ``g_i``, individual addressing, disorder, etc. Each atom lives in its own copy of an [`NLevelSpace`](@ref). Symbolic sums over a site index keep the bookkeeping compact at the algebra level.
+
+```julia
+using SecondQuantizedAlgebra
+@variables N
+
+ha = NLevelSpace(:atom, 2)
+hc = FockSpace(:cavity)
+h  = hc ⊗ ha
+
+i  = Index(h, :i, N, ha)
+σ(α, β) = IndexedOperator(Transition(h, :σ, α, β, 2), i)
+gi = IndexedVariable(:g, i)
+
+@qnumbers a::Destroy(h, 1)
+H_TC = Σ(gi * (a' * σ(1, 2) + a * σ(2, 1)), i)
+```
+
+The full Hilbert space is ``\dim(\mathcal{H}_{\text{atom}})^{N}`` — exponential in `N`. Numeric simulation is tractable only for small `N` (typically `N ≲ 10` for `n=2` levels). The diagonal-split machinery, completeness, and per-atom σᵍᵍ rewriting are documented in [Symbolic Sums and Indices](@ref) and [Ordering Conventions](@ref).
+
+## Indistinguishable atoms — `CollectiveTransition`
+
+Use this when the dynamics preserves permutation symmetry: Dicke physics, single-mode driving with no atom-resolved coupling, superradiance with identical atoms, etc. The state stays in the *symmetric (bosonic) subspace*, whose dimension is polynomial in `N`:
+
+```math
+\dim \mathcal{H}_\text{sym} = \binom{N + n - 1}{n - 1}
+```
+
+For `N = 100` atoms with `n = 3` levels: full Hilbert space ``\sim 10^{47}``, symmetric subspace ``5151``. The latter is the only thing you can actually simulate.
+
+[`CollectiveTransition`](@ref) ``S^{ij} = \sum_k \sigma_k^{ij}`` is the operator on this subspace:
+
+```julia
+h = NLevelSpace(:atom, 3)
+S(i, j) = CollectiveTransition(h, :S, i, j)
+
+S(1, 2) * S(2, 3)         # eagerly normal-ordered: S(1, 3) + S(2, 3) * S(1, 2)
+```
+
+These satisfy the ``\mathfrak{su}(N)`` Lie algebra ``[S^{ij}, S^{kl}] = \delta_{jk} S^{il} - \delta_{li} S^{kj}``, and the swap rule fires eagerly under [`NormalOrder`](@ref) so derivations stay in the closed collective form.
+
+### Numeric conversion
+
+Numeric simulation requires a `QuantumOpticsBase.ManyBodyBasis` over the single-atom basis with `bosonstates`:
+
+```julia
+using QuantumOpticsBase
+n_atoms = 100
+b1 = NLevelBasis(3)
+b  = ManyBodyBasis(b1, bosonstates(b1, n_atoms))    # symmetric subspace
+
+to_numeric(S(1, 2), b)   # many-body operator on the symmetric subspace
+```
+
+The number of atoms `N` enters only here, not at the algebra layer.
+
+## Comparison
+
+| | Distinguishable atoms | Indistinguishable atoms |
+|---|---|---|
+| Representation | [`Σ`](@ref) of [`IndexedOperator`](@ref) on a [`ProductSpace`](@ref) | [`CollectiveTransition`](@ref) on a single [`NLevelSpace`](@ref) |
+| Atoms | individually addressable | symmetric subspace, no atom labels |
+| Hilbert-space dim | ``n^N`` | ``\binom{N+n-1}{n-1}`` |
+| Numeric scaling | exponential in `N` | polynomial in `N` |
+| Algebra | per-atom Transition rules + diagonal split | ``\mathfrak{su}(N)`` Lie algebra (closed) |
+| Ground-state completeness | applies (``\sigma^{gg} = 1 - \sum_{k \neq g}\sigma^{kk}``) | does not apply (``\sum_j S^{jj} = N \cdot I``, deferred to numeric layer) |
+| Typical use case | Tavis–Cummings with disorder, lattice models, individual addressing | Dicke model, superradiant laser with identical atoms |
+
+## Don't mix
+
+[`Transition`](@ref) and [`CollectiveTransition`](@ref) on the *same* [`NLevelSpace`](@ref) are physically incompatible representations — pick one regime per atomic subspace. The package will not throw if you write `Transition(h, :σ, 1, 2) * CollectiveTransition(h, :S, 2, 1)`, but the result is meaningless: `Transition` lives in the full Hilbert space and `CollectiveTransition` in the symmetric subspace, and there is no canonical embedding between them at the algebra level.

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -2,5 +2,6 @@
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
+OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
 QuantumOpticsBase = "4f57444f-1401-5e15-980d-4471b28d5678"
 SecondQuantizedAlgebra = "f7aa4685-e143-4cb6-a7f3-073579757907"

--- a/examples/dicke_superradiance.jl
+++ b/examples/dicke_superradiance.jl
@@ -1,0 +1,153 @@
+# # Dicke Superradiance with Collective Transitions
+#
+# `N` identical two-level atoms coupled to a single cavity mode form the
+# **Tavis-Cummings / Dicke** system.  When all atoms see the same field, the
+# dynamics preserves permutation symmetry — states stay in the *symmetric
+# (bosonic) subspace*, whose dimension grows polynomially in `N` rather than
+# as `2^N`.  This is exactly the regime where
+# [`CollectiveTransition`](@ref SecondQuantizedAlgebra.CollectiveTransition)
+# operators ``S^{ij} = \sum_k \sigma_k^{ij}`` are the natural variables.
+#
+# In this example we:
+# 1. Build the Tavis-Cummings Hamiltonian with collective atom operators,
+# 2. Verify the ``\mathfrak{su}(N)`` Lie-algebra commutators that drive the
+#    dynamics,
+# 3. Propagate the fully-inverted state ``|\text{vac}\rangle \otimes |e\rangle^{\otimes N}``
+#    and observe the **superradiant burst** — the cavity occupation builds up
+#    faster than for `N` independent atoms thanks to the ``\sqrt{N}`` enhanced
+#    coupling.
+#
+# See [Collective Atoms — Two Regimes](@ref) for when to use
+# `CollectiveTransition` versus indexed [`Σ`](@ref SecondQuantizedAlgebra.Σ)
+# on a `ProductSpace`.
+
+# ## Setup
+#
+# A single cavity mode plus an `NLevelSpace` for the (collective) two-level atoms.
+# The atomic Hilbert space is a *single* `NLevelSpace` — the collective
+# operator already represents the sum over `N` atoms; we don't build a product
+# of `N` atom spaces.
+
+using SecondQuantizedAlgebra
+
+hc = FockSpace(:cavity)
+ha = NLevelSpace(:atom, (:g, :e))
+h = hc ⊗ ha
+
+@qnumbers a::Destroy(h, 1)
+
+S(α, β) = CollectiveTransition(h, :S, α, β, 2)
+
+@variables ωc ωa g
+
+# ## Tavis-Cummings Hamiltonian
+#
+# In the rotating-wave approximation,
+#
+# ```math
+# H = \omega_c\, a^\dagger a
+#   + \omega_a\, S^{ee}
+#   + g\bigl(a^\dagger S^{ge} + a\, S^{eg}\bigr).
+# ```
+
+H = ωc * a' * a + ωa * S(:e, :e) + g * (a' * S(:g, :e) + a * S(:e, :g))
+
+# ## Lie-algebra structure
+#
+# The collective operators satisfy
+# ``[S^{ij}, S^{kl}] = \delta_{jk}\, S^{il} - \delta_{li}\, S^{kj}``.  Under the
+# default [`NormalOrder`](@ref SecondQuantizedAlgebra.NormalOrder) convention
+# this commutator fires eagerly during multiplication, so derivations stay in
+# closed collective form rather than expanding into explicit per-atom sums.
+# A quick sanity check:
+
+commutator(S(:e, :g), S(:g, :e))   # = S^{ee} − S^{gg}
+
+# Equations of motion follow directly.  Cavity field:
+
+i_dadt = 1im * commutator(H, a)
+
+# Atomic coherence ``S^{ge}``:
+
+i_dSgedt = 1im * commutator(H, S(:g, :e))
+
+# Notice that the right-hand sides stay compact — every term is either a
+# `CollectiveTransition` or a Fock operator times one.  The same derivation in
+# the indexed representation (a single `IndexedOperator` per atom on a
+# `ProductSpace`) would carry around `Σ` symbols with explicit non-equality
+# constraints.
+
+# ## Hilbert-space scaling
+#
+# The symmetric subspace dimension is ``\binom{N + n - 1}{n - 1}``, polynomial
+# in `N`, whereas the full product space scales as ``n^N``.  For two-level
+# atoms (`n = 2`) the contrast is striking: `N = 100` atoms is `2^100 ≈ 10^30`
+# in the full product space — entirely intractable — but only `101` in the
+# symmetric subspace.
+
+# ## Numerical simulation: superradiant burst
+#
+# We propagate the fully inverted state under the resonant Hamiltonian
+# (``\omega_c = \omega_a``) and watch the cavity occupation build up.
+# The atomic basis is the symmetric subspace built from `bosonstates`.
+
+using QuantumOpticsBase
+using OrdinaryDiffEqTsit5
+using CairoMakie
+
+function build_problem(N; n_cav_max = N + 4, ω = 1.0, g_val = 0.05)
+    b_cav = FockBasis(n_cav_max)
+    b_atom = NLevelBasis(2)
+    b_collective = ManyBodyBasis(b_atom, bosonstates(b_atom, N))
+    b = b_cav ⊗ b_collective
+
+    subs = Dict(ωc => ω, ωa => ω, g => g_val)
+    H_num = to_numeric(substitute(H, subs), b)
+
+    # Initial state: cavity vacuum, all atoms excited.
+    # In `bosonstates` ordering, [N - k, k] has k atoms in level 2 (|e⟩).
+    ψ0 = fockstate(b_cav, 0) ⊗ basisstate(b_collective, [0, N])
+
+    n_cav_op = to_numeric(a' * a, b)
+
+    return H_num, ψ0, n_cav_op
+end
+
+# We sweep three system sizes.  Time is given in units of the inverse coupling
+# ``g^{-1}`` so that the single-atom Rabi period is ``2\pi``.
+
+times = collect(range(0, 80.0; length = 401))
+g_val = 0.05
+
+results = Dict{Int, Vector{Float64}}()
+
+for N in (1, 5, 20)
+    H_num, ψ0, n_cav_op = build_problem(N; g_val = g_val)
+    rhs(dψ, ψ, _, _) = (dψ .= -im .* (H_num * Ket(ψ0.basis, ψ)).data; nothing)
+    prob = ODEProblem(rhs, ψ0.data, (times[1], times[end]))
+    sol = solve(prob, Tsit5(); saveat = times, abstol = 1.0e-10, reltol = 1.0e-10)
+    n_cav_t = [real(QuantumOpticsBase.expect(n_cav_op, Ket(ψ0.basis, ψ))) for ψ in sol.u]
+    results[N] = n_cav_t
+end
+
+# Plot the cavity occupation:
+
+fig = Figure(; size = (640, 360))
+ax = Axis(
+    fig[1, 1];
+    xlabel = "time  (g·t)",
+    ylabel = "⟨a†a⟩(t)",
+    title = "Tavis-Cummings build-up: collective coupling enhances Rabi rate",
+)
+for N in (1, 5, 20)
+    n_cav_t = results[N]
+    lines!(ax, g_val .* times, n_cav_t; label = "N = $N", linewidth = 2)
+end
+axislegend(ax; position = :rb)
+fig
+
+# The first peak in the cavity occupation arrives faster as `N` grows, with the
+# Rabi frequency scaling as ``g\sqrt{N}`` — the hallmark of collective
+# light-matter coupling.  In the `CollectiveTransition` representation this is
+# direct: one `NLevelSpace`, one cavity, polynomial-size symmetric subspace,
+# regardless of `N`.

--- a/src/SecondQuantizedAlgebra.jl
+++ b/src/SecondQuantizedAlgebra.jl
@@ -80,7 +80,7 @@ end
 
 
 export FockSpace, ProductSpace,
-    NLevelSpace, Transition,
+    NLevelSpace, Transition, CollectiveTransition,
     PauliSpace, Pauli,
     SpinSpace, Spin,
     PhaseSpace, Position, Momentum,

--- a/src/latexify_recipes.jl
+++ b/src/latexify_recipes.jl
@@ -41,6 +41,10 @@ end
     return Expr(:latexifymerge, "{$(x.name)}$(suffix)$(transition_idx_script[]){{$(x.i)$(x.j)}}")
 end
 
+@latexrecipe function f(x::CollectiveTransition)
+    return Expr(:latexifymerge, "{$(x.name)}$(transition_idx_script[]){{$(x.i)$(x.j)}}")
+end
+
 @latexrecipe function f(x::Pauli)
     ax = _xyz_sym[x.axis]
     suffix = _latex_index_suffix(x.index)

--- a/src/nlevel.jl
+++ b/src/nlevel.jl
@@ -147,27 +147,25 @@ ladder(::Transition) = 0
 """
     CollectiveTransition <: QSym
 
-Collective transition operator ``S^{ij} = \\sum_{k=1}^{N} \\sigma_k^{ij}`` on an
-[`NLevelSpace`](@ref). Lives in the *symmetric (bosonic) subspace* of `N`
-indistinguishable atoms — the natural representation for Dicke-style physics
-where atoms are not individually addressable and the dynamics preserves
-permutation symmetry.
+Collective transition operator ``S^{ij} = \\sum_{k=1}^{N} \\sigma_k^{ij}`` for `N`
+identical atoms on an [`NLevelSpace`](@ref). The operator acts on the
+*symmetric (bosonic) subspace* of the `N`-atom Hilbert space, which is what
+`QuantumOpticsBase.ManyBodyBasis` with `bosonstates` represents numerically.
 
 # When to use this vs indexed `Σ`
 
-Two regimes — pick the one that matches your physics, do **not** mix:
+Both [`CollectiveTransition`](@ref) and indexed [`Σ`](@ref) describe `N`
+identical atoms in collective dynamics. They differ in *computational strategy*
+— pick the one that matches the kind of result you want, do **not** mix them on
+the same `NLevelSpace`:
 
-| | Distinguishable atoms | Indistinguishable atoms |
+| | Indexed `Σ` (cumulant approach) | `CollectiveTransition` (exact symmetric subspace) |
 |---|---|---|
-| Representation | [`Σ`](@ref) of [`IndexedOperator`](@ref) on a [`ProductSpace`](@ref) | `CollectiveTransition` on a single [`NLevelSpace`](@ref) |
-| Physical setting | Atom-resolved coupling, disorder, individual addressing | Dicke physics, single-mode driving, no disorder |
-| Hilbert space | Full ``n^N`` (one atom per subspace) | Symmetric subspace, dimension ``\\binom{N+n-1}{n-1}`` |
-| Numeric scaling | Exponential in `N` | Polynomial in `N` — tractable for thousands |
-
-For the same physics where both are valid (e.g. Tavis–Cummings with identical
-atoms), the indexed form is preferred; `CollectiveTransition` is for problems
-where the symmetric-subspace assumption is essential, typically because the full
-Hilbert space is intractable.
+| Numerical strategy | Cumulant / mean-field truncation | Exact diagonalization on `ManyBodyBasis` |
+| Hilbert space at numeric layer | Single representative atom + symbolic site index | Full symmetric subspace, dim ``\\binom{N+n-1}{n-1}`` |
+| Site-dependent parameters (e.g. ``g_i``) | Yes, via [`IndexedVariable`](@ref) | No (atoms identical by construction) |
+| `N` scaling | Large `N` (truncation order at solve time) | Modest `N` — tractable in the polynomial subspace |
+| Output | Mean-field / cumulant equations of motion | State vector / density matrix |
 
 # Algebra
 
@@ -177,10 +175,11 @@ The operators satisfy the ``\\mathfrak{su}(N)`` Lie algebra
 operator with the larger `(i, j)` (lex-descending) ends up on the left, with
 the appropriate remainder terms appended.
 
-The single-atom completeness ``\\sigma^{gg} = 1 - \\sum_{k \\neq g}\\sigma^{kk}``
-does **not** apply here — for collective operators ``\\sum_j S^{jj} = N \\cdot I``
-(note the ``N``), and that rewrite is intentionally left for numeric-conversion
-time rather than the symbolic algebra.
+Single-atom completeness ``\\sigma^{gg} = 1 - \\sum_{k \\neq g}\\sigma^{kk}`` does
+**not** apply to collective operators — collectively
+``\\sum_j S^{jj} = N \\cdot I`` (note the ``N``, not ``1``). Since the algebra
+layer is `N`-agnostic, that rewrite is left for the numeric-conversion layer
+where `N` is determined by the basis.
 
 # Construction
 

--- a/src/nlevel.jl
+++ b/src/nlevel.jl
@@ -143,3 +143,120 @@ Base.hash(a::Transition, h::UInt) = hash(:Transition, hash(a.name, hash(a.i, has
 
 # Ladder (not applicable to Transition)
 ladder(::Transition) = 0
+
+"""
+    CollectiveTransition <: QSym
+
+Collective transition operator ``S^{ij} = \\sum_{k=1}^{N} \\sigma_k^{ij}`` on an
+[`NLevelSpace`](@ref). Lives in the *symmetric (bosonic) subspace* of `N`
+indistinguishable atoms — the natural representation for Dicke-style physics
+where atoms are not individually addressable and the dynamics preserves
+permutation symmetry.
+
+# When to use this vs indexed `Σ`
+
+Two regimes — pick the one that matches your physics, do **not** mix:
+
+| | Distinguishable atoms | Indistinguishable atoms |
+|---|---|---|
+| Representation | [`Σ`](@ref) of [`IndexedOperator`](@ref) on a [`ProductSpace`](@ref) | `CollectiveTransition` on a single [`NLevelSpace`](@ref) |
+| Physical setting | Atom-resolved coupling, disorder, individual addressing | Dicke physics, single-mode driving, no disorder |
+| Hilbert space | Full ``n^N`` (one atom per subspace) | Symmetric subspace, dimension ``\\binom{N+n-1}{n-1}`` |
+| Numeric scaling | Exponential in `N` | Polynomial in `N` — tractable for thousands |
+
+For the same physics where both are valid (e.g. Tavis–Cummings with identical
+atoms), the indexed form is preferred; `CollectiveTransition` is for problems
+where the symmetric-subspace assumption is essential, typically because the full
+Hilbert space is intractable.
+
+# Algebra
+
+The operators satisfy the ``\\mathfrak{su}(N)`` Lie algebra
+``[S^{ij}, S^{kl}] = \\delta_{jk} S^{il} - \\delta_{li} S^{kj}``. Under
+[`NormalOrder`](@ref) this commutator fires eagerly during multiplication: the
+operator with the larger `(i, j)` (lex-descending) ends up on the left, with
+the appropriate remainder terms appended.
+
+The single-atom completeness ``\\sigma^{gg} = 1 - \\sum_{k \\neq g}\\sigma^{kk}``
+does **not** apply here — for collective operators ``\\sum_j S^{jj} = N \\cdot I``
+(note the ``N``), and that rewrite is intentionally left for numeric-conversion
+time rather than the symbolic algebra.
+
+# Construction
+
+```julia
+h = NLevelSpace(:atom, 3)
+S(i, j) = CollectiveTransition(h, :S, i, j)
+S(2, 1) * S(1, 3)         # ordered — stays as written
+S(1, 2) * S(2, 3)         # unordered — eagerly normal-ordered: S(1, 3) + S(2, 3) * S(1, 2)
+```
+
+In a [`ProductSpace`](@ref) supply the subspace index:
+```julia
+hp = FockSpace(:c) ⊗ NLevelSpace(:a, 3)
+S = CollectiveTransition(hp, :S, 1, 2, 2)
+```
+
+# Numeric conversion
+
+Numeric simulation requires a `QuantumOpticsBase.ManyBodyBasis` built over the
+single-atom basis with `bosonstates`:
+```julia
+b1 = NLevelBasis(3)
+b  = ManyBodyBasis(b1, bosonstates(b1, N))    # symmetric subspace for N atoms
+to_numeric(S(1, 2), b)                        # many-body operator
+```
+"""
+struct CollectiveTransition <: QSym
+    name::Symbol
+    i::Int
+    j::Int
+    space_index::Int
+    index::Index   # always NO_INDEX; carried for site-sort compatibility
+end
+
+# Construction from Hilbert spaces
+function CollectiveTransition(h::NLevelSpace, name::Symbol, i::Int, j::Int)
+    1 <= i <= h.n || throw(ArgumentError("Level i=$i out of range 1:$(h.n)"))
+    1 <= j <= h.n || throw(ArgumentError("Level j=$j out of range 1:$(h.n)"))
+    return CollectiveTransition(name, i, j, 1, NO_INDEX)
+end
+function CollectiveTransition(h::NLevelSpace, name::Symbol, i::Symbol, j::Symbol)
+    return CollectiveTransition(name, _level_index(h, i), _level_index(h, j), 1, NO_INDEX)
+end
+function CollectiveTransition(h::ProductSpace, name::Symbol, i::Int, j::Int, idx::Int)
+    1 <= idx <= length(h.spaces) || throw(ArgumentError("Index $idx out of range"))
+    space = h.spaces[idx]
+    space isa NLevelSpace || throw(ArgumentError("Space at index $idx is not an NLevelSpace"))
+    1 <= i <= space.n || throw(ArgumentError("Level i=$i out of range 1:$(space.n)"))
+    1 <= j <= space.n || throw(ArgumentError("Level j=$j out of range 1:$(space.n)"))
+    return CollectiveTransition(name, i, j, idx, NO_INDEX)
+end
+function CollectiveTransition(h::ProductSpace, name::Symbol, i::Symbol, j::Symbol, idx::Int)
+    1 <= idx <= length(h.spaces) || throw(ArgumentError("Index $idx out of range"))
+    space = h.spaces[idx]
+    space isa NLevelSpace || throw(ArgumentError("Space at index $idx is not an NLevelSpace"))
+    return CollectiveTransition(name, _level_index(space, i), _level_index(space, j), idx, NO_INDEX)
+end
+
+# Auto-detect subspace when the ProductSpace contains exactly one NLevelSpace.
+CollectiveTransition(h::ProductSpace, name::Symbol, i::Int, j::Int) =
+    CollectiveTransition(h, name, i, j, _unique_subspace_index(h, NLevelSpace))
+CollectiveTransition(h::ProductSpace, name::Symbol, i::Symbol, j::Symbol) =
+    CollectiveTransition(h, name, i, j, _unique_subspace_index(h, NLevelSpace))
+
+# IndexedOperator does not apply — CollectiveTransition is already a sum over atoms.
+function IndexedOperator(::CollectiveTransition, ::Index)
+    throw(ArgumentError("CollectiveTransition is already a sum over atoms; indexing it is not meaningful. Use Transition for individually-addressed atoms."))
+end
+
+# Adjoint: (S^{ij})† = S^{ji}
+Base.adjoint(op::CollectiveTransition) = CollectiveTransition(op.name, op.j, op.i, op.space_index, op.index)
+
+# Equality and hashing
+Base.isequal(a::CollectiveTransition, b::CollectiveTransition) = a.name == b.name && a.i == b.i && a.j == b.j && a.space_index == b.space_index && a.index == b.index
+Base.:(==)(a::CollectiveTransition, b::CollectiveTransition) = isequal(a, b)
+Base.hash(a::CollectiveTransition, h::UInt) = hash(:CollectiveTransition, hash(a.name, hash(a.i, hash(a.j, hash(a.space_index, hash(a.index, h))))))
+
+# Ladder (not applicable)
+ladder(::CollectiveTransition) = 0

--- a/src/numeric.jl
+++ b/src/numeric.jl
@@ -156,6 +156,13 @@ Converts `op` to numeric form via [`to_numeric`](@ref), then calls
 `QuantumOpticsBase.expect`. Also handles averaged `BasicSymbolic` expressions
 by first calling [`undo_average`](@ref).
 
+When `state` is an `AbstractVector` of states the operator is converted once
+(sparsified for the operator-typed methods) and the expectation value is
+returned as a `Vector` of the same length. Plain numbers (`Number`) and
+constants pass through unchanged — *they are returned as a scalar even for
+vector input*, so that `f.(numeric_average.(args, Ref(states))...)` broadcasts
+constants over operator-evaluated vectors as expected.
+
 # Examples
 ```julia
 using QuantumOpticsBase
@@ -164,9 +171,12 @@ h = FockSpace(:f)
 b = FockBasis(10)
 ψ = coherentstate(b, 2.0)
 numeric_average(a' * a, ψ)    # ≈ 4.0
+
+ψs = [coherentstate(b, α) for α in (1.0, 2.0, 3.0)]
+numeric_average(a' * a, ψs)   # 3-element Vector ≈ [1.0, 4.0, 9.0]
 ```
 
-See also [`to_numeric`](@ref), [`average`](@ref).
+See also [`to_numeric`](@ref), [`average`](@ref), [`expect`](@ref).
 """
 function numeric_average(op::QField, state::QuantumState; kwargs...)
     op_num = to_numeric(op, state; kwargs...)

--- a/src/numeric.jl
+++ b/src/numeric.jl
@@ -39,6 +39,19 @@ function to_numeric(op::Transition, b::QuantumOpticsBase.NLevelBasis; kwargs...)
     return QuantumOpticsBase.transition(b, op.i, op.j)
 end
 
+# CollectiveTransition: S^{ij} = Σ_k σ_k^{ij} acts on the symmetric (bosonic)
+# many-body subspace built from a single-atom NLevelBasis. The number of atoms
+# N is determined by the basis; the algebra is N-agnostic.
+function to_numeric(op::CollectiveTransition, b::QuantumOpticsBase.ManyBodyBasis; kwargs...)
+    onebody = b.onebodybasis
+    onebody isa QuantumOpticsBase.NLevelBasis || throw(
+        ArgumentError(
+            "CollectiveTransition requires a ManyBodyBasis with NLevelBasis as the one-body basis; got $(typeof(onebody))"
+        )
+    )
+    return QuantumOpticsBase.manybodyoperator(b, QuantumOpticsBase.transition(onebody, op.i, op.j))
+end
+
 # Pauli — requires spin-1/2 basis
 function to_numeric(op::Pauli, b::QuantumOpticsBase.SpinBasis; kwargs...)
     b.spinnumber == 1 // 2 || throw(ArgumentError("Pauli operators require SpinBasis(1//2), got SpinBasis($(b.spinnumber))"))
@@ -191,6 +204,22 @@ function numeric_average(avg::SymbolicUtils.BasicSymbolic, state::QuantumState; 
     error("numeric_average not implemented for $(typeof(avg))")
 end
 
+# Vector-of-states variants for averaged expressions: route AvgFunc through the
+# fast QField path, broadcast otherwise.
+function numeric_average(avg::SymbolicUtils.BasicSymbolic, states::AbstractVector; kwargs...)
+    if SymbolicUtils.iscall(avg) && SymbolicUtils.operation(avg) isa AvgFunc
+        op = undo_average(avg)
+        return numeric_average(op, states; kwargs...)
+    end
+    return [numeric_average(avg, s; kwargs...) for s in states]
+end
+function numeric_average(x::Num, states::AbstractVector; kwargs...)
+    return numeric_average(SymbolicUtils.unwrap(x), states; kwargs...)
+end
+function numeric_average(x::Number, ::AbstractVector; kwargs...)
+    return x
+end
+
 # --- to_numeric / numeric_average with Dict parameter substitution ---
 
 function to_numeric(op::QSym, b::QuantumOpticsBase.Basis, d::Dict; kwargs...)
@@ -250,17 +279,33 @@ function numeric_average(avg::SymbolicUtils.BasicSymbolic, state::QuantumState, 
     error("numeric_average not implemented for $(typeof(avg))")
 end
 
-"""
-    expect(op, state; kwargs...)
-    expect(op, state, d::Dict; kwargs...)
+# Vector-of-states variants with Dict substitution.
+function numeric_average(avg::SymbolicUtils.BasicSymbolic, states::AbstractVector, d::Dict; kwargs...)
+    if SymbolicUtils.iscall(avg) && SymbolicUtils.operation(avg) isa AvgFunc
+        op = undo_average(avg)
+        return numeric_average(op, states, d; kwargs...)
+    end
+    return [numeric_average(avg, s, d; kwargs...) for s in states]
+end
+function numeric_average(x::Num, states::AbstractVector, d::Dict; kwargs...)
+    return numeric_average(SymbolicUtils.unwrap(x), states, d; kwargs...)
+end
+function numeric_average(x::Number, ::AbstractVector, ::Dict; kwargs...)
+    return x
+end
 
-Compute the expectation value ``\\langle \\hat{O} \\rangle``. Alias for
-[`numeric_average`](@ref); imported from `QuantumOpticsBase` so the same name
-works for both numeric and symbolic operands.
+"""
+    expect(op::QField, state; kwargs...)
+    expect(op::QField, state, d::Dict; kwargs...)
+
+Compute the expectation value ``\\langle \\hat{O} \\rangle`` of a symbolic
+operator expression. Alias for [`numeric_average`](@ref); imported from
+`QuantumOpticsBase` so the same name works for both numeric and symbolic
+operands.
+
+For averaged `BasicSymbolic` expressions (returned by [`average`](@ref)) call
+[`numeric_average`](@ref) directly — defining `expect` overloads on
+`SymbolicUtils.BasicSymbolic` would be type-piracy.
 """
 expect(op::QField, state; kwargs...) = numeric_average(op, state; kwargs...)
 expect(op::QField, state, d::Dict; kwargs...) = numeric_average(op, state, d; kwargs...)
-expect(avg::SymbolicUtils.BasicSymbolic, state; kwargs...) = numeric_average(avg, state; kwargs...)
-expect(avg::SymbolicUtils.BasicSymbolic, state, d::Dict; kwargs...) = numeric_average(avg, state, d; kwargs...)
-expect(x::Num, state; kwargs...) = numeric_average(x, state; kwargs...)
-expect(x::Num, state, d::Dict; kwargs...) = numeric_average(x, state, d; kwargs...)

--- a/src/ordering.jl
+++ b/src/ordering.jl
@@ -226,8 +226,44 @@ function _apply_ordering_swap!(
         return true
     end
 
+    # CollectiveTransition: [S^{ij}, S^{kl}] = δ_{jk} S^{il} − δ_{li} S^{kj}.
+    # Canonical: descending lex on (i, j) — keep larger (i, j) on the left.
+    if a isa CollectiveTransition && b isa CollectiveTransition &&
+            _same_site(a, b) && a.name == b.name && !_isordered_ct(a, b)
+        # Push the swapped pair (b·a) — now ordered, no further swap fires
+        swapped = copy(ops)
+        swapped[i], swapped[i + 1] = swapped[i + 1], swapped[i]
+        push!(worklist, (c, swapped))
+
+        # +δ_{a.j, b.i} S^{a.i, b.j}
+        if a.j == b.i
+            new_ops = copy(ops)
+            new_ops[i] = CollectiveTransition(a.name, a.i, b.j, a.space_index, a.index)
+            deleteat!(new_ops, i + 1)
+            push!(worklist, (c, new_ops))
+        end
+        # −δ_{b.j, a.i} S^{b.i, a.j}
+        if b.j == a.i
+            new_ops = copy(ops)
+            new_ops[i] = CollectiveTransition(a.name, b.i, a.j, a.space_index, a.index)
+            deleteat!(new_ops, i + 1)
+            push!(worklist, (_neg_cnum(c), new_ops))
+        end
+        return true
+    end
+
     return false
 end
+
+"""
+    _isordered_ct(a::CollectiveTransition, b::CollectiveTransition) -> Bool
+
+Canonical-order check for [`CollectiveTransition`](@ref) pairs: returns `true`
+iff `(a.i, a.j) ≥ (b.i, b.j)` in descending lex order. Pairs that fail this
+test fire the eager su(N) swap rule in [`_apply_ordering_swap!`](@ref).
+"""
+_isordered_ct(a::CollectiveTransition, b::CollectiveTransition) =
+    a.i > b.i || (a.i == b.i && a.j >= b.j)
 
 # LazyOrder: skip all ordering (identity transform)
 function _apply_ordering(arg_c::CNum, ops::Vector{QSym}, ::LazyOrder)

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -55,6 +55,12 @@ function Base.show(io::IO, x::Transition)
     return _write_subscript(io, x.j)
 end
 
+function Base.show(io::IO, x::CollectiveTransition)
+    print(io, x.name)
+    _write_subscript(io, x.i)
+    return _write_subscript(io, x.j)
+end
+
 const _xyz_sym = (:x, :y, :z)
 function Base.show(io::IO, x::Pauli)
     print(io, x.name)

--- a/src/qadd.jl
+++ b/src/qadd.jl
@@ -133,6 +133,7 @@ _type_order(::Pauli) = 3
 _type_order(::Spin) = 4
 _type_order(::Position) = 5
 _type_order(::Momentum) = 6
+_type_order(::CollectiveTransition) = 7
 
 """
     Base.getindex(q::QAdd, key::Vector{QSym}) -> CNum

--- a/test/collective_transition_test.jl
+++ b/test/collective_transition_test.jl
@@ -1,0 +1,227 @@
+using SecondQuantizedAlgebra
+using QuantumOpticsBase
+using Test
+import SecondQuantizedAlgebra: simplify, QAdd, QSym, CollectiveTransition, NO_INDEX
+
+@testset "CollectiveTransition" begin
+    h = NLevelSpace(:atom, 3, 1)
+    S(i, j) = CollectiveTransition(h, :S, i, j)
+
+    # ============================================================================
+    # Field-level invariants
+    # ============================================================================
+    @testset "Struct fields and basic properties" begin
+        op = S(1, 2)
+        @test op.name == :S
+        @test op.i == 1
+        @test op.j == 2
+        @test op.space_index == 1
+        @test op.index == NO_INDEX        # never a user-supplied index
+
+        # Adjoint flips i and j
+        @test S(1, 2)' == S(2, 1)
+        @test S(2, 2)' == S(2, 2)
+        @test S(1, 3)' == S(3, 1)
+
+        # Equality discriminates on every field
+        @test S(1, 2) == S(1, 2)
+        @test S(1, 2) != S(2, 1)
+        @test S(1, 2) != S(1, 3)
+
+        # Different name → different operator
+        @test CollectiveTransition(h, :S, 1, 2) != CollectiveTransition(h, :T, 1, 2)
+    end
+
+    @testset "Bounds checking" begin
+        @test_throws ArgumentError CollectiveTransition(h, :S, 0, 2)
+        @test_throws ArgumentError CollectiveTransition(h, :S, 1, 4)
+        @test_throws ArgumentError CollectiveTransition(h, :S, -1, 2)
+    end
+
+    @testset "Symbolic-level constructor" begin
+        h_sym = NLevelSpace(:atom, (:g, :e, :a))
+        Sge = CollectiveTransition(h_sym, :S, :g, :e)
+        @test Sge.i == 1
+        @test Sge.j == 2
+    end
+
+    @testset "ProductSpace constructors" begin
+        hf = FockSpace(:cavity)
+        hp = hf ⊗ h
+        S_p(i, j) = CollectiveTransition(hp, :S, i, j, 2)
+        @test S_p(1, 2).space_index == 2
+        @test S_p(1, 2).i == 1
+        @test S_p(1, 2).j == 2
+
+        # Auto-detect (only one NLevelSpace in hp)
+        @test CollectiveTransition(hp, :S, 1, 2) == S_p(1, 2)
+
+        # Symbolic levels
+        h_sym = NLevelSpace(:atom, (:g, :e))
+        hp_sym = hf ⊗ h_sym
+        Sge = CollectiveTransition(hp_sym, :S, :g, :e, 2)
+        @test Sge.i == 1
+        @test Sge.j == 2
+    end
+
+    @testset "Indexing is rejected" begin
+        i = Index(h, :i, 10, h)
+        @test_throws ArgumentError IndexedOperator(S(1, 2), i)
+    end
+
+    # ============================================================================
+    # Algebra under NormalOrder (default)
+    # ============================================================================
+    @testset "Ordered products stay unchanged (single dict entry)" begin
+        # Descending lex on (i, j): largest left
+        for (a, b) in [
+                (S(2, 1), S(1, 3)),    # a.i=2 > b.i=1
+                (S(2, 3), S(2, 1)),    # a.i==b.i, a.j=3 > b.j=1
+                (S(2, 2), S(2, 2)),    # equal
+                (S(3, 1), S(1, 2)),    # a.i=3 > b.i=1
+            ]
+            r = a * b
+            @test r isa QAdd
+            @test length(r) == 1
+            ops, c = only(collect(r))
+            @test ops == [a, b]
+            @test c == 1
+        end
+    end
+
+    @testset "Unordered products fire the commutator (su(N) algebra)" begin
+        # S(1,2) * S(2,3): a.j == b.i = 2 → +S(1,3); b.j == a.i?? 3 != 1, no second term.
+        # Result: S(1,3) + S(2,3) * S(1,2)
+        @test isequal(S(1, 2) * S(2, 3), S(1, 3) + S(2, 3) * S(1, 2))
+
+        # S(1,2) * S(1,3): a.j != b.i, b.j != a.i → just a swap.
+        # Result: S(1,3) * S(1,2)
+        @test isequal(S(1, 2) * S(1, 3), S(1, 3) * S(1, 2))
+
+        # S(1,2) * S(3,1): a.j != b.i (2 != 3); b.j == a.i = 1 → -S(3,2).
+        # Result: -S(3,2) + S(3,1) * S(1,2)
+        @test isequal(S(1, 2) * S(3, 1), -S(3, 2) + S(3, 1) * S(1, 2))
+
+        # S(1,2) * S(1,1): _isordered((1,2),(1,1))? a.i==b.i, a.j=2 >= b.j=1 → ordered.
+        # No swap fires; the product stays as [S(1,2), S(1,1)].
+        r = S(1, 2) * S(1, 1)
+        @test length(r) == 1
+        ops, _ = only(collect(r))
+        @test ops == [S(1, 2), S(1, 1)]
+
+        # S(1,1) * S(1,2): unordered. a.j == b.i = 1 → +S(1,2). b.j != a.i → no second.
+        # Result: S(1,2) + S(1,2) * S(1,1)
+        @test isequal(S(1, 1) * S(1, 2), S(1, 2) + S(1, 2) * S(1, 1))
+    end
+
+    @testset "Self-product and zero compositions" begin
+        # S(1,2) * S(1,2): _isordered((1,2),(1,2))? equal → ordered. Stays.
+        r = S(1, 2) * S(1, 2)
+        @test length(r) == 1
+        ops, _ = only(collect(r))
+        @test ops == [S(1, 2), S(1, 2)]
+    end
+
+    @testset "Different subspaces do not interact" begin
+        h2 = NLevelSpace(:atom2, 3, 1)
+        hp = h ⊗ h2
+        S1(i, j) = CollectiveTransition(hp, :S1, i, j, 1)
+        S2(i, j) = CollectiveTransition(hp, :S2, i, j, 2)
+
+        # Cross-subspace ops commute (different sites, site-sort handles order)
+        @test isequal(S2(2, 1) * S1(1, 3), S1(1, 3) * S2(2, 1))
+    end
+
+    @testset "Different names on same subspace do not interact" begin
+        # Two CT operators on the same NLevelSpace but with different names.
+        # The swap rule requires a.name == b.name; otherwise nothing fires.
+        T(i, j) = CollectiveTransition(h, :T, i, j)
+        r = S(1, 2) * T(2, 1)
+        @test length(r) == 1
+        ops, _ = only(collect(r))
+        @test length(ops) == 2
+    end
+
+    @testset "Mixing with Fock operators (Tavis-Cummings-like)" begin
+        hc = FockSpace(:cavity)
+        hp = hc ⊗ h
+        @qnumbers a::Destroy(hp, 1)
+        Sp(i, j) = CollectiveTransition(hp, :S, i, j, 2)
+
+        # Commuting transitions: S(1,2) and S(2,3) → S(1,3) on the diagonal.
+        # Multiplied by 'a' from the right (Fock commutes through atoms):
+        @test isequal(Sp(1, 2) * Sp(2, 3) * a, a * Sp(1, 3) + Sp(2, 3) * Sp(1, 2) * a)
+
+        # Two transitions that yield zero commutator: [S(1,2), S(1,3)] = 0 by su(N) rule.
+        @test isequal(Sp(1, 2) * Sp(1, 3) * a, Sp(1, 3) * Sp(1, 2) * a)
+        @test iszero(simplify(Sp(1, 2) * Sp(1, 3) * a - a * Sp(1, 3) * Sp(1, 2)))
+    end
+
+    @testset "CollectiveTransition and Transition are unrelated operators" begin
+        # Both can sit on the same NLevelSpace, but they are NOT the same physics.
+        # CT's index is NO_INDEX; Transition's user-supplied index differs.
+        # _same_site requires matching index, so Transition·CT never fires reductions.
+        σ(i, j) = Transition(h, :σ, i, j)
+        @test S(1, 2) != σ(1, 2)
+        @test hash(S(1, 2)) != hash(σ(1, 2))
+        # Product: stored as 2-op product (no algebra fires)
+        r = S(1, 2) * σ(2, 1)
+        @test length(r) == 1
+        ops, _ = only(collect(r))
+        @test length(ops) == 2
+    end
+
+    # ============================================================================
+    # Numeric conversion through ManyBodyBasis (symmetric subspace)
+    # ============================================================================
+    @testset "Numeric conversion: ManyBodyBasis" begin
+        n_levels = 4
+        n_atoms = 3
+        h4 = NLevelSpace(:atoms, n_levels, 1)
+        S4(i, j) = CollectiveTransition(h4, :S, i, j)
+
+        b1 = NLevelBasis(n_levels)
+        b = ManyBodyBasis(b1, bosonstates(b1, n_atoms))
+
+        # Symmetric subspace dim = binomial(n_atoms + n_levels - 1, n_levels - 1)
+        @test length(b) == binomial(n_atoms + n_levels - 1, n_levels - 1)
+
+        for i in 1:n_levels, j in 1:n_levels
+            op = S4(i, j)
+            num = to_numeric(op, b)
+            expected = QuantumOpticsBase.manybodyoperator(b, QuantumOpticsBase.transition(b1, i, j))
+            @test num == expected
+        end
+
+        # Sum of population operators = N · I (symmetric subspace identity)
+        pop_sum = sum(to_numeric(S4(k, k), b) for k in 1:n_levels)
+        @test pop_sum ≈ Float64(n_atoms) * one(b)
+
+        # Hermitian conjugation: S^{ij}† == S^{ji}
+        @test to_numeric(S4(1, 2)', b) ≈ dagger(to_numeric(S4(1, 2), b))
+
+        # Algebra: S^{12} S^{21} - S^{21} S^{12} = S^{11} - S^{22}
+        lhs = to_numeric(S4(1, 2), b) * to_numeric(S4(2, 1), b) -
+            to_numeric(S4(2, 1), b) * to_numeric(S4(1, 2), b)
+        rhs = to_numeric(S4(1, 1), b) - to_numeric(S4(2, 2), b)
+        @test lhs ≈ rhs
+    end
+
+    @testset "Numeric conversion: rejects non-NLevel one-body basis" begin
+        n_atoms = 2
+        b1 = FockBasis(3)
+        b = ManyBodyBasis(b1, bosonstates(b1, n_atoms))
+        Sx = CollectiveTransition(NLevelSpace(:atom, 3, 1), :S, 1, 2)
+        @test_throws ArgumentError to_numeric(Sx, b)
+    end
+
+    # ============================================================================
+    # Type stability
+    # ============================================================================
+    @testset "Type stability" begin
+        @inferred CollectiveTransition(h, :S, 1, 2)
+        @inferred adjoint(S(1, 2))
+        @inferred isequal(S(1, 2), S(2, 1))
+        @inferred hash(S(1, 2), UInt(0))
+    end
+end

--- a/test/collective_transition_test.jl
+++ b/test/collective_transition_test.jl
@@ -102,6 +102,13 @@ import SecondQuantizedAlgebra: simplify, QAdd, QSym, CollectiveTransition, NO_IN
         # Result: -S(3,2) + S(3,1) * S(1,2)
         @test isequal(S(1, 2) * S(3, 1), -S(3, 2) + S(3, 1) * S(1, 2))
 
+        # Both delta terms fire simultaneously: S(1,2) * S(2,1).
+        # a.j == b.i = 2 → +S(a.i, b.j) = +S(1,1).
+        # b.j == a.i = 1 → -S(b.i, a.j) = -S(2,2).
+        # Result: S(1,1) - S(2,2) + S(2,1) * S(1,2). This is exactly the su(2)
+        # commutator [S(1,2), S(2,1)] = S(1,1) - S(2,2) plus the swapped pair.
+        @test isequal(S(1, 2) * S(2, 1), S(1, 1) - S(2, 2) + S(2, 1) * S(1, 2))
+
         # S(1,2) * S(1,1): _isordered((1,2),(1,1))? a.i==b.i, a.j=2 >= b.j=1 → ordered.
         # No swap fires; the product stays as [S(1,2), S(1,1)].
         r = S(1, 2) * S(1, 1)
@@ -114,12 +121,26 @@ import SecondQuantizedAlgebra: simplify, QAdd, QSym, CollectiveTransition, NO_IN
         @test isequal(S(1, 1) * S(1, 2), S(1, 2) + S(1, 2) * S(1, 1))
     end
 
-    @testset "Self-product and zero compositions" begin
-        # S(1,2) * S(1,2): _isordered((1,2),(1,2))? equal → ordered. Stays.
+    @testset "Self-product is non-zero (kept as 2-op product)" begin
+        # S(1,2) * S(1,2): _isordered((1,2),(1,2))? equal → ordered. Stays as a
+        # 2-op product. Note: collectively S^{12}·S^{12} = Σ_{k≠l} σ_k^{12} σ_l^{12}
+        # is generally non-zero (only the k=l diagonal vanishes via σ²=0), so
+        # leaving it un-collapsed is correct.
         r = S(1, 2) * S(1, 2)
         @test length(r) == 1
         ops, _ = only(collect(r))
         @test ops == [S(1, 2), S(1, 2)]
+    end
+
+    @testset "Adjoint involution" begin
+        # `adjoint` reverses operator order and daggers each but does *not* re-run
+        # the eager swap rule, so multi-op adjoints may not be in `_isordered_ct`
+        # canonical form (apply `normal_order`/`simplify` if you need to compare).
+        # The involution property holds independently:
+        @test S(1, 2)'' == S(1, 2)
+        @test S(2, 1)'' == S(2, 1)
+        @test isequal((S(1, 2) * S(2, 3))'', S(1, 2) * S(2, 3))
+        @test isequal((S(1, 2) * S(2, 1))'', S(1, 2) * S(2, 1))
     end
 
     @testset "Different subspaces do not interact" begin

--- a/test/numeric_test.jl
+++ b/test/numeric_test.jl
@@ -260,7 +260,9 @@ using Test
         # expect alias matches
         @test expect(a, ψs) ≈ numeric_average(a, ψs)
         @test expect(a' * a, ψs[1]) ≈ numeric_average(a' * a, ψs[1])
-        @test expect(average(a), ψs[1]) ≈ numeric_average(average(a), ψs[1])
+        # `expect` is QField-only (type-piracy concerns); use `numeric_average`
+        # for averaged BasicSymbolic expressions.
+        @test numeric_average(average(a), ψs[1]) ≈ αs[1]
 
         # Empty vector errors
         empty_ψs = typeof(ψs[1])[]


### PR DESCRIPTION
Adds `CollectiveTransition` for `N` identical atoms with closed `su(N)` Lie-algebra arithmetic, paired with `ManyBodyBasis` numeric conversion for exact dynamics in the symmetric (bosonic) subspace.

This ports PR #102 onto the redesign-v2 architecture, with several improvements:
- Concrete struct fields (passes `CheckConcreteStructs`); no `metadata`, no `ClusterSpace` dependency
- Eager `su(N)` swap rule slot in `_apply_ordering_swap!`, mirroring the existing `Spin` pattern — same architecture, no new abstractions
- Type-piracy-clean: `expect` aliases narrowed to `QField` (the original PR's `Average` type doesn't exist in v2)
- A docs page that nails the "which one do I use?" 

## When this is the right tool

Both indexed `Σ` (already in v2) and `CollectiveTransition` describe `N` identical atoms in collective dynamics — they are *complementary computational strategies*, not different physics:

| | Indexed `Σ` (cumulant approach) | `CollectiveTransition` (exact symmetric subspace) |
|---|---|---|
| Numerical strategy | Cumulant / mean-field truncation | Exact diagonalization on `ManyBodyBasis` |
| Hilbert space at numeric layer | Single representative atom + symbolic site index | Full symmetric subspace, dim ``\binom{N+n-1}{n-1}`` |
| Site-dependent parameters (e.g. `g_i`) | Yes, via `IndexedVariable` | No (atoms identical by construction) |
| `N` scaling | Large `N` (truncation order at solve time) | Modest `N` — tractable in the polynomial subspace |
| Output | Mean-field / cumulant equations of motion | State vector / density matrix on the symmetric subspace |

`CollectiveTransition`'s niche is the intersection of three properties that no other path in the package provides together:
1. **Symbolic algebra** — derive Heisenberg equations or dissipators in closed `su(N)` form before going to numerics.
2. **Exact dynamics** — no cumulant truncation; full state vector, finite-`N` corrections, entanglement entropy, etc.
3. **`N` too big for the full product space, small enough for the symmetric subspace** (roughly `N ∈ [5, ~thousands]` for two-level atoms).

If you only need two of those, simpler tools cover the use case: indexed `Σ` for symbolic + cumulant (any `N`); plain `QuantumOpticsBase.manybodyoperator` for exact + numeric only (small `N`, no symbolic layer needed). The niche is real but narrow — the docs page is upfront about this.

Pick the one that matches your computational strategy, and don't mix them on the same `NLevelSpace`.


## Design notes

- **Struct**: `CollectiveTransition <: QSym` with concrete fields `name, i, j, space_index, index` (always `NO_INDEX`; carried for site-sort compatibility). No `n_atoms` field — `N` enters only at numeric-conversion time via `ManyBodyBasis`. Algebra stays Hilbert-space-decoupled.
- **Algebra**: ``[S^{ij}, S^{kl}] = \delta_{jk} S^{il} - \delta_{li} S^{kj}`` fires eagerly under `NormalOrder` via a new branch in `_apply_ordering_swap!`. Convention `_isordered_ct` keeps the larger `(i, j)` on the left (descending lex).
- **Single-atom completeness skipped**: for collective operators ``\sum_j S^{jj} = N \cdot I`` (note the `N`, not `1`), so per-atom `σ^{gg} → 1 − σ^{kk}` rewriting doesn't apply. Deferred to numeric-conversion layer where `N` is known.
- **No `IndexedOperator(::CollectiveTransition, ::Index)`**: rejected with `ArgumentError` — `CollectiveTransition` already represents the sum.
- **Numeric conversion**: `to_numeric(::CollectiveTransition, ::ManyBodyBasis)` builds a many-body operator from the single-atom `transition`. Rejects non-`NLevelBasis` one-body bases.


## References

- Original feature: #102 (@ChristophHotter)
