### PR TITLE
perf: for commuting commutators and symbolic rational coefficients

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -131,4 +131,5 @@ These names keep their meaning across the migration. Code that only uses them sh
 
 [v0.5.0]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/releases/tag/v0.5.0
 [v0.5.1]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/releases/tag/v0.5.1
+[v0.5.2]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/releases/tag/v0.5.2
 [#156]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/issues/156

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,14 @@ All notable changes to [`SecondQuantizedAlgebra.jl`](https://github.com/qojulia/
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.5.2]
+
+### Fixed
+
+- Commuting commutators with symbolic rational coefficients no longer bloat derived expressions ([#162](https://github.com/qojulia/SecondQuantizedAlgebra.jl/pull/162)). Deriving `[Hₖ, op]` for an `Hₖ` that commutes with `op` should vanish, but with a rational coupling such as `γ/|xᵢ-xⱼ|³` the two halves land as `γ/D + (-γ)/D`, which Symbolics leaves un-combined and `_iszero_cnum` does not see as zero; the spurious term then survives and inflates every downstream RHS. Fixed at two levels:
+  - `_addto_key!` cancels exact-negation prefactor pairs for symbolic coefficients (the numeric path stays allocation-free).
+  - `commutator` distributes over terms and skips disjoint-subspace pairs (`[aₖ, bₗ] = 0`), so the cancelling products are never formed.
+
 ## [v0.5.1]
 
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SecondQuantizedAlgebra"
 uuid = "f7aa4685-e143-4cb6-a7f3-073579757907"
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/algebra/algebra.jl
+++ b/src/algebra/algebra.jl
@@ -370,12 +370,44 @@ function commutator(a::QSym, b::QSym)
     return a * b - b * a
 end
 
-commutator(a::QAdd, b::QSym) = a * b - b * a
-commutator(a::QSym, b::QAdd) = a * b - b * a
+# Skip term pairs on disjoint subspaces: [aₖ,bₗ]=0, so their products only cancel.
+function commutator(a::QAdd, b::QSym)
+    sb = b.space_index
+    d = QTermDict()
+    indices = _EMPTY_INDICES
+    for (ta, ca) in a.arguments
+        sb in acts_on(ta) || continue
+        qa = QAdd(QTermDict(_copy_key(ta) => ca), a.indices)
+        indices = _merge_unique(indices, _merge_into!(d, qa * b - b * qa))
+    end
+    return QAdd(d, _drop_unused_indices(d, indices))
+end
+commutator(a::QSym, b::QAdd) = -commutator(b, a)
 
 function commutator(a::QAdd, b::QAdd)
     isequal(a, b) && return _zero_qadd()
-    return a * b - b * a
+    bside = [(tb, cb, acts_on(tb)) for (tb, cb) in b.arguments]
+    d = QTermDict()
+    indices = _EMPTY_INDICES
+    for (ta, ca) in a.arguments
+        aon_a = acts_on(ta)
+        qa = QAdd(QTermDict(_copy_key(ta) => ca), a.indices)
+        for (tb, cb, aon_b) in bside
+            isdisjoint(aon_a, aon_b) && continue
+            qb = QAdd(QTermDict(_copy_key(tb) => cb), b.indices)
+            indices = _merge_unique(indices, _merge_into!(d, qa * qb - qb * qa))
+        end
+    end
+    return QAdd(d, _drop_unused_indices(d, indices))
+end
+
+# Collect every term of `r` into `d` (summing like terms); return `r`'s indices
+# so the caller can accumulate the summation scope as the `+` chain would.
+function _merge_into!(d::QTermDict, r::QAdd)
+    for (term, c) in r.arguments
+        _addto_key!(d, _copy_key(term), c)
+    end
+    return r.indices
 end
 
 """

--- a/src/average.jl
+++ b/src/average.jl
@@ -313,10 +313,16 @@ acts_on(op::QSym) = Int[op.space_index]
 acts_on(::Number) = Int[]
 acts_on(x::Num) = acts_on(SymbolicUtils.unwrap(x))
 
+function acts_on(t::QTerm)
+    aon = Int[x.space_index for x in t.ops]
+    unique!(sort!(aon))
+    return aon
+end
+
 function acts_on(op::QAdd)
     aon = Int[]
-    for term in keys(op.arguments), x in term.ops
-        push!(aon, x.space_index)
+    for term in keys(op.arguments)
+        append!(aon, acts_on(term))
     end
     unique!(sort!(aon))
     return aon

--- a/src/expressions/cnum.jl
+++ b/src/expressions/cnum.jl
@@ -41,6 +41,20 @@ end
     return _iszero_num(c.re) && _iszero_num(c.im)
 end
 
+# `unwrap` returns a `BasicSymbolic` even for numeric constants, so test the
+# node kind rather than `isa Number`.
+@inline function _is_symbolic_num(x::Num)
+    v = SymbolicUtils.unwrap(x)
+    return SymbolicUtils.issym(v) || SymbolicUtils.iscall(v)
+end
+
+@inline _is_symbolic_cnum(c::CNum) = _is_symbolic_num(c.re) || _is_symbolic_num(c.im)
+
+# Structural `a == -b`; see `_addto_key!` for why this is needed.
+@inline function _isneg_cnum(a::CNum, b::CNum)
+    return isequal(a.re, -b.re) && isequal(a.im, -b.im)
+end
+
 # Short-circuit CNum arithmetic: most prefactors have zero imaginary part,
 # so we avoid 4 Num multiplications and 2 Num subtractions in the common case.
 @inline function _mul_cnum(a::CNum, b::CNum)

--- a/src/expressions/qterm.jl
+++ b/src/expressions/qterm.jl
@@ -180,7 +180,9 @@ function _addto_key!(d::QTermDict, term::QTerm, c::CNum)
         return d
     end
     new_c = _add_cnum(existing, c)
-    if _iszero_cnum(new_c)
+    # Symbolics keeps `γ/D + (-γ)/D` un-combined, so `_iszero_cnum` misses such
+    # cancellations; fall back to an exact-negation test for symbolic coefficients.
+    if _iszero_cnum(new_c) || (_is_symbolic_cnum(new_c) && _isneg_cnum(existing, c))
         delete!(d, term)
     else
         d[term] = new_c

--- a/test/arithmetics/commutator_test.jl
+++ b/test/arithmetics/commutator_test.jl
@@ -411,3 +411,20 @@ end
     @test isequal(decay(a' * a), simplify(-κ * (a' * a)))
     @test isequal(decay(σ(2, 2, j)), simplify(R - (R + γ) * σ(2, 2, j)))
 end
+
+@testset "Regression: rational coefficients cancel exactly" begin
+    # Symbolics leaves `J0/D + (-J0)/D` un-combined, so a commuting `[Hₖ,op]=0` with a
+    # rational coupling J0/|xᵢ-xⱼ|³ must still cancel exactly, not survive and bloat RHSs.
+    h = NLevelSpace(:a1, (:g, :e)) ⊗ NLevelSpace(:a2, (:g, :e)) ⊗ NLevelSpace(:a3, (:g, :e))
+    σ(x, y, k) = Transition(h, Symbol(:σ_, k), x, y, k)
+    @variables J0 x1 x2 x3
+    D(p, q) = abs(p - q)^3
+    Hk = (J0 / D(x2, x3)) * (σ(:e, :g, 2) * σ(:g, :e, 3) + σ(:g, :e, 2) * σ(:e, :g, 3))
+    @test iszero(commutator(Hk, σ(:g, :e, 1)))                       # disjoint atoms
+    @test iszero((J0 / D(x1, x2)) * σ(:g, :e, 1) - (J0 / D(x1, x2)) * σ(:g, :e, 1))
+    # A genuine (shared-space) rational-coefficient commutator is preserved:
+    hf = FockSpace(:c)
+    a = Destroy(hf, :a)
+    @variables Δ
+    @test iszero(commutator((J0 / Δ) * (a' * a), a) + (J0 / Δ) * a)  # [J/Δ·a†a, a] = -J/Δ·a
+end

--- a/test/arithmetics/internals_test.jl
+++ b/test/arithmetics/internals_test.jl
@@ -142,6 +142,24 @@ end
             @test isempty(out)
         end
 
+        @testset "canonicalize_to_dict!: symbolic prefactor cancellation" begin
+            @variables γ D
+            # γ/D + (-γ)/D is structurally non-zero to Symbolics (the `Div` nodes
+            # are left un-combined), so exact-negation collection must drop the term.
+            out = QTermDict()
+            _canonicalize_to_dict!(out, QSym[a], _to_cnum(γ / D), _EMPTY_NE)
+            _canonicalize_to_dict!(out, QSym[a], _to_cnum(-γ / D), _EMPTY_NE)
+            @test isempty(out)
+        end
+
+        @testset "canonicalize_to_dict!: distinct symbolic prefactors kept" begin
+            @variables γ D β
+            out = QTermDict()
+            _canonicalize_to_dict!(out, QSym[a], _to_cnum(γ / D), _EMPTY_NE)
+            _canonicalize_to_dict!(out, QSym[a], _to_cnum(β / D), _EMPTY_NE)
+            @test length(out) == 1
+        end
+
         @testset "_reduce_ops: Transition composition" begin
             σ12 = Transition(hn, :σ, 1, 2)
             σ23 = Transition(hn, :σ, 2, 3)


### PR DESCRIPTION

- Commuting commutators with symbolic rational coefficients no longer bloat derived expressions ([#162](https://github.com/qojulia/SecondQuantizedAlgebra.jl/pull/162)). Deriving `[Hₖ, op]` for an `Hₖ` that commutes with `op` should vanish, but with a rational coupling such as `γ/|xᵢ-xⱼ|³` the two halves land as `γ/D + (-γ)/D`, which Symbolics leaves un-combined and `_iszero_cnum` does not see as zero; the spurious term then survives and inflates every downstream RHS. Fixed at two levels:
  - `_addto_key!` cancels exact-negation prefactor pairs for symbolic coefficients (the numeric path stays allocation-free).
  - `commutator` distributes over terms and skips disjoint-subspace pairs (`[aₖ, bₗ] = 0`), so the cancelling products are never formed.