### PR TITLE
Drop un-combined zero coefficients when collecting like terms

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,12 @@ All notable changes to [`SecondQuantizedAlgebra.jl`](https://github.com/qojulia/
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Like-term collection no longer keeps zero coefficients that differ only in representation. A sign flip turns `λ/2` (a `/` node) into the rational `(-1//2)·λ` (a `*` node), so the exact-negation test in `_addto_key!` saw two different trees and the term survived. For example `commutator(im*H, a*a)` with a quadratic (squeezing) Hamiltonian `H = Δ·a†a + (λ/2)(a†² + a²)` kept spurious fourth-order operators (`a†a†aa`, `aaaa`) with a zero-but-un-combined coefficient `λ/2 - (1//2)λ`, which downstream `average`/cumulant code then had to special-case. The negation test now canonicalizes division-by-an-integer-constant to the rational form before comparing, so the two representations cancel. The check is O(1) for the common non-fraction prefactors, so nested-commutator performance is unaffected ([#167](https://github.com/qojulia/SecondQuantizedAlgebra.jl/pull/167)).
+
 ## [v0.5.2]
 
 ### Fixed

--- a/src/expressions/cnum.jl
+++ b/src/expressions/cnum.jl
@@ -75,8 +75,10 @@ end
 # negation test above stays O(1) for the common (non-fraction) prefactors.
 function _canon_div(x::Num)
     v = SymbolicUtils.unwrap(x)
-    (v isa SymbolicUtils.BasicSymbolic && SymbolicUtils.iscall(v) &&
-        SymbolicUtils.operation(v) === (/)) || return x
+    (
+        v isa SymbolicUtils.BasicSymbolic && SymbolicUtils.iscall(v) &&
+            SymbolicUtils.operation(v) === (/)
+    ) || return x
     args = SymbolicUtils.arguments(v)
     length(args) == 2 || return x
     n = Symbolics.value(args[2])

--- a/src/expressions/cnum.jl
+++ b/src/expressions/cnum.jl
@@ -52,7 +52,36 @@ end
 
 # Structural `a == -b`; see `_addto_key!` for why this is needed.
 @inline function _isneg_cnum(a::CNum, b::CNum)
-    return isequal(a.re, -b.re) && isequal(a.im, -b.im)
+    return _isneg_num(a.re, b.re) && _isneg_num(a.im, b.im)
+end
+
+# `x == -y` for symbolic prefactors. The cheap structural test misses cancellations that
+# differ only in representation: a sign flip turns `λ/2` (a `/` node) into the rational
+# `(-1//2)λ` (a `*` node), and `isequal` sees two different trees. Retry with the
+# division-by-constant canonicalized so the two forms compare equal.
+@inline function _isneg_num(x::Num, y::Num)
+    ny = -y
+    isequal(x, ny) && return true
+    cx = _canon_div(x)
+    cny = _canon_div(ny)
+    # `_canon_div` returns its argument unchanged for non-fraction prefactors; if neither
+    # side canonicalized there is nothing new to compare, so skip the repeat `isequal`.
+    (cx === x && cny === ny) && return false
+    return isequal(cx, cny)
+end
+
+# Canonicalize `p / n` (division by an integer literal) to `(1//n) * p`, matching the form
+# a sign flip produces. A no-op unless the top-level operation is `/` by an integer, so the
+# negation test above stays O(1) for the common (non-fraction) prefactors.
+function _canon_div(x::Num)
+    v = SymbolicUtils.unwrap(x)
+    (v isa SymbolicUtils.BasicSymbolic && SymbolicUtils.iscall(v) &&
+        SymbolicUtils.operation(v) === (/)) || return x
+    args = SymbolicUtils.arguments(v)
+    length(args) == 2 || return x
+    n = Symbolics.value(args[2])
+    (n isa Integer && !iszero(n)) || return x
+    return (1 // n) * Num(args[1])
 end
 
 # Short-circuit CNum arithmetic: most prefactors have zero imaginary part,

--- a/test/arithmetics/commutator_test.jl
+++ b/test/arithmetics/commutator_test.jl
@@ -428,3 +428,15 @@ end
     @variables Δ
     @test iszero(commutator((J0 / Δ) * (a' * a), a) + (J0 / Δ) * a)  # [J/Δ·a†a, a] = -J/Δ·a
 end
+
+@testset "Regression: un-combined zero coefficients drop on merge (λ/2 vs (1//2)λ)" begin
+    # `λ/2 + (-(1//2)λ)` is zero but differently represented, so the exact-negation path
+    # misses it; the merge must still drop it, else spurious 4th-order operators survive.
+    h = FockSpace(:cav)
+    a = Destroy(h, :a)
+    @variables Δ λ
+    H = Δ * a' * a + (λ / 2) * (a' * a' + a * a)
+    cm = commutator(im * H, a * a)  # = -2iΔ·a² - iλ(2a†a + 1): no 4th-order terms
+    @test all(length(operators(t)) <= 2 for t in sorted_arguments(cm))
+    @test iszero((λ / 2) * (a * a) - ((1 // 2) * λ) * (a * a))
+end

--- a/test/quality/JET.jl
+++ b/test/quality/JET.jl
@@ -154,6 +154,8 @@ end
             "SecondQuantizedAlgebra.:+",
             "SecondQuantizedAlgebra.:^",
             "SecondQuantizedAlgebra._average(",
+            "SecondQuantizedAlgebra.://",
+            "SecondQuantizedAlgebra.isequal(",
         ]
         allowed_numeric_reports = vcat(
             allowed_hotpath_reports,


### PR DESCRIPTION

`_addto_key!` collects like terms and deletes a key when its combined coefficient is zero. It used the structural `_iszero_cnum` plus an exact-negation fast path (added in #162 for `γ/D + (-γ)/D`). Both miss cancellations whose two halves are **equal but differently represented** rationals, e.g. `λ/2` vs `(1//2)λ`. Such a term is mathematically zero but survives in the `QAdd`.

Concretely, for a quadratic (squeezing) Hamiltonian `H = Δ·a†a + (λ/2)(a†² + a²)`:

```julia
commutator(im*H, a*a)
# kept:  ... + (im*(λ/2 - (1//2)λ)) * a†a†aa + (im*(λ/2 - (1//2)λ)) * aaaa
#        i.e. two spurious 4th-order operators with a zero-but-un-combined coefficient
```

`iszero` on that coefficient returns `true` (Symbolics expands), and `average` drops it, but the operator-level `QAdd` retained it. Downstream consumers (e.g. QuantumCumulants' cumulant/`average_and_truncate` path) then had to special-case the phantom terms, and an exact (no-truncation) mean-field expansion of a quadratic Hamiltonian failed to close because completion chased these never-vanishing higher-order moments.

## Fix

Add `_iszero_cnum_expand` (an expanding zero test) and use it as a final fallback in `_addto_key!`, gated behind the existing `_is_symbolic_cnum` guard:

- numeric and structural fast paths are unchanged (common merges stay allocation-free);
- the expand runs only for symbolic coefficients that did not cancel structurally or by exact negation, which is exactly the problematic case.

After the fix, `commutator(im*H, a*a)` returns only the 0th/2nd-order terms, and `(λ/2)·aa - (1//2)λ·aa` collapses to an empty (`iszero`) `QAdd`.