### PR TITLE
Add order_key: total identity-faithful operator ordering

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,12 @@ All notable changes to [`SecondQuantizedAlgebra.jl`](https://github.com/qojulia/
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.6.1]
+
+### Added
+
+- `order_key`, `term_order_key`, `qadd_order_key` (public): a total, identity-faithful structural ordering for operators, products, and sums, built from one per-type `order_key` method. The key ties two operators exactly when they are `isequal`, giving downstream packages a reproducible way to pick canonical representatives and compare expressions without round-tripping through `show` or `hash` ([#169](https://github.com/qojulia/SecondQuantizedAlgebra.jl/pull/169)).
+
 ## [v0.6.0]
 
 ### Changed
@@ -139,4 +145,5 @@ These names keep their meaning across the migration. Code that only uses them sh
 [v0.5.1]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/releases/tag/v0.5.1
 [v0.5.2]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/releases/tag/v0.5.2
 [v0.6.0]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/releases/tag/v0.6.0
+[v0.6.1]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/releases/tag/v0.6.1
 [#156]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/issues/156

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SecondQuantizedAlgebra"
 uuid = "f7aa4685-e143-4cb6-a7f3-073579757907"
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -205,6 +205,12 @@ sorted_arguments
 ```
 
 ```@docs
+order_key
+term_order_key
+qadd_order_key
+```
+
+```@docs
 substitute
 ```
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/qojulia/SecondQuantizedAlgebra.jl/tree/main)
 
+### Added
+
+- `order_key`, `term_order_key`, `qadd_order_key` (public): a total, identity-faithful structural ordering for operators, products, and sums, built from one per-type `order_key` method. Ties exactly when `isequal`, so downstream packages can pick canonical representatives and compare expressions reproducibly without round-tripping through `show` or `hash`.
+
 ## [v0.5.0]
 
 Breaking release: redesign of the algebraic core. Most public entry points keep their names and meaning. The substantive changes fall into three groups: direct renames, constructs replaced by more general machinery, and behavioural changes in shared API names. This entry is the migration reference for users with code written against **SecondQuantizedAlgebra.jl v0.4** or **QuantumCumulants.jl**, which shares the v0.4 API surface.

--- a/docs/src/devdocs.md
+++ b/docs/src/devdocs.md
@@ -309,6 +309,16 @@ Two exported helpers handle Hermitian conjugation on mixed operator/symbolic exp
 These cannot be wired directly to `Base.conj`/`Base.adjoint` on `SymbolicUtils.BasicSymbolic` because that would be type piracy — defining methods on `Base` functions for a type we don't own. Downstream packages (QuantumCumulants.jl, QuantumInputOutput.jl) call these explicitly.
 
 
+## Ordering keys: three distinct orders
+
+SQA carries three orderings that must not be conflated, because each answers a different question.
+
+**`_site_compare` (partial, commutation).** The `SiteCmp` three-way comparator drives `_partial_sort!` during normal ordering. It is deliberately *not* identity-faithful: it returns `Equal` for operators that differ only in `axis` (Pauli/Spin) or levels `i,j` (Transition), because it encodes which adjacent factors may be reordered, not whether two operators are the same. It is also partial (`Undetermined` for free indices with no resolving `ne`).
+
+**`_full_op_key`/`_sort_key` (display sort).** Used by `sorted_arguments` for deterministic *display* order only. Also not identity-faithful: it omits axis and levels, so two distinct operators can share a display key. Fine for printing, wrong for keying.
+
+**`order_key`/`term_order_key`/`qadd_order_key` (total, identity-faithful).** The public ordering used by downstream packages (QuantumCumulants.jl) to pick canonical representatives and compare expressions reproducibly. The contract is `order_key(a) == order_key(b)` iff `isequal(a, b)`: the key carries every identity field, so it is a strict total order that never ties distinct operators. `order_key` has one method per concrete `QSym` subtype, co-located with that type's `isequal`/`hash`, and no generic `QSym` fallback, so a new operator type added without a key is a loud `MethodError` rather than a silent field-dropping collision. It is preferred over hashing for ordering because Julia's `hash` is not stable across versions/platforms (which would make canonical-representative choice, and therefore generated equations, irreproducible) and collides; hashing remains correct for equality-only dedup via `Dict`/`Set`, which use `hash` plus `isequal`.
+
 ## Printing and LaTeX
 
 **Terminal printing** uses Unicode: `†` for dagger, subscript digits (`₀`-`₉`) for Transition levels, `σx`/`σy`/`σz` for Pauli axes. Summations render as `Σ(i=1:N)`.

--- a/src/SecondQuantizedAlgebra.jl
+++ b/src/SecondQuantizedAlgebra.jl
@@ -117,7 +117,8 @@ end
 
 @public HilbertSpace, QField, QSym,
     QAdd, QTerm, QTermDict, has_sum_metadata, get_sum_indices, get_sum_non_equal,
-    transition_superscript, constraint_pairs
+    transition_superscript, constraint_pairs,
+    order_key, term_order_key, qadd_order_key
 
 include("precompile.jl")
 

--- a/src/expressions/index_types.jl
+++ b/src/expressions/index_types.jl
@@ -61,6 +61,9 @@ function Base.hash(a::Index, h::UInt)
 end
 Base.isless(a::Index, b::Index) = (a.space_index, a.name) < (b.space_index, b.name)
 
+# Ordering key for an index; mirrors isless's (space_index, name) (range excluded).
+_index_key(idx::Index) = (idx.space_index, idx.name)
+
 function Index(h::HilbertSpace, name::Symbol, range::Union{Int, Num}, space::HilbertSpace)
     si = _find_space_index(h, space)
     sym_var = SymbolicUtils.Sym{SymbolicUtils.SymReal}(name; type = Int)

--- a/src/expressions/qadd.jl
+++ b/src/expressions/qadd.jl
@@ -166,6 +166,30 @@ end
 
 _term_sort_key(ops::Vector{QSym}) = (length(ops), map(_full_op_key, ops)...)
 _full_op_key(op::QSym) = (_sort_key(op)..., _type_order(op), op.name)
+
+"""
+    term_order_key(t::QTerm) -> Tuple
+
+Total ordering key for an operator product, built from `order_key`: length, then
+operator-by-operator, then the canonical-sorted non-equal constraints.
+"""
+term_order_key(t::QTerm) = (length(t.ops), map(order_key, t.ops), _ne_sort_key(t.ne))
+
+"""
+    qadd_order_key(q::QAdd) -> Vector
+
+Total, reproducible ordering key for a sum: its term/coefficient pairs in sorted order, so
+two `QAdd`s compare with `<` on their keys and tie exactly when they are `isequal`. The
+coefficient contributes its printed form (a reproducible tiebreak, not a numeric order).
+"""
+function qadd_order_key(q::QAdd)
+    pairs = [(term_order_key(t), _coeff_key(c)) for (t, c) in q.arguments]
+    sort!(pairs)
+    return pairs
+end
+
+_coeff_key(c::CNum) = (string(c.re), string(c.im))
+
 _type_order(::Destroy) = 0
 _type_order(::Create) = 1
 _type_order(::Transition) = 2

--- a/src/operators/fock.jl
+++ b/src/operators/fock.jl
@@ -99,6 +99,9 @@ Base.:(==)(a::Create, b::Create) = isequal(a, b)
 Base.hash(a::Destroy, h::UInt) = hash(:Destroy, hash(a.name, hash(a.space_index, hash(a.index, h))))
 Base.hash(a::Create, h::UInt) = hash(:Create, hash(a.name, hash(a.space_index, hash(a.index, h))))
 
+order_key(o::Destroy) = (_type_order(Destroy), o.space_index, o.name, _index_key(o.index))
+order_key(o::Create) = (_type_order(Create), o.space_index, o.name, _index_key(o.index))
+
 """
     ladder(op::QSym)
 

--- a/src/operators/nlevel.jl
+++ b/src/operators/nlevel.jl
@@ -137,6 +137,8 @@ Base.:(==)(a::Transition, b::Transition) = isequal(a, b)
 
 Base.hash(a::Transition, h::UInt) = hash(:Transition, hash(a.name, hash(a.i, hash(a.j, hash(a.space_index, hash(a.index, hash(a.ground_state, hash(a.n_levels, h))))))))
 
+order_key(o::Transition) = (_type_order(Transition), o.space_index, o.name, _index_key(o.index), o.i, o.j, o.ground_state, o.n_levels)
+
 ladder(::Transition) = 0
 
 # --- Operator hooks ---

--- a/src/operators/operators.jl
+++ b/src/operators/operators.jl
@@ -265,6 +265,16 @@ _type_order(::Type{Spin}) = 4
 _type_order(::Type{Position}) = 5
 _type_order(::Type{Momentum}) = 6
 
+"""
+    order_key(op::QSym) -> Tuple
+
+Total, identity-faithful ordering key: a comparable tuple that orders operators
+reproducibly and ties two exactly when they are `isequal`. One method per concrete
+subtype (no generic `QSym` fallback), so a new operator type without a key is a loud
+`MethodError`, not a silent field-dropping collision.
+"""
+function order_key end
+
 # Generic fallbacks for cross-type operator pairs (always distinct sites).
 _can_commute(::QSym, ::QSym) = true
 _commute_pair(a::QSym, b::QSym) = (b, a, _CNUM_ZERO, _EMPTY_OPS)

--- a/src/operators/pauli.jl
+++ b/src/operators/pauli.jl
@@ -75,6 +75,8 @@ Base.:(==)(a::Pauli, b::Pauli) = isequal(a, b)
 
 Base.hash(a::Pauli, h::UInt) = hash(:Pauli, hash(a.name, hash(a.axis, hash(a.space_index, hash(a.index, h)))))
 
+order_key(o::Pauli) = (_type_order(Pauli), o.space_index, o.name, _index_key(o.index), o.axis)
+
 ladder(::Pauli) = 0
 
 # --- Operator hooks ---

--- a/src/operators/phase_space.jl
+++ b/src/operators/phase_space.jl
@@ -97,6 +97,9 @@ Base.:(==)(a::Momentum, b::Momentum) = isequal(a, b)
 Base.hash(a::Position, h::UInt) = hash(:Position, hash(a.name, hash(a.space_index, hash(a.index, h))))
 Base.hash(a::Momentum, h::UInt) = hash(:Momentum, hash(a.name, hash(a.space_index, hash(a.index, h))))
 
+order_key(o::Position) = (_type_order(Position), o.space_index, o.name, _index_key(o.index))
+order_key(o::Momentum) = (_type_order(Momentum), o.space_index, o.name, _index_key(o.index))
+
 ladder(::Position) = 0
 ladder(::Momentum) = 1
 

--- a/src/operators/spin.jl
+++ b/src/operators/spin.jl
@@ -74,6 +74,8 @@ Base.:(==)(a::Spin, b::Spin) = isequal(a, b)
 
 Base.hash(a::Spin, h::UInt) = hash(:Spin, hash(a.name, hash(a.axis, hash(a.space_index, hash(a.index, h)))))
 
+order_key(o::Spin) = (_type_order(Spin), o.space_index, o.name, _index_key(o.index), o.axis)
+
 ladder(::Spin) = 0
 
 # --- Operator hooks ---

--- a/test/order_key_test.jl
+++ b/test/order_key_test.jl
@@ -59,3 +59,49 @@ const order_key = SecondQuantizedAlgebra.order_key
         end
     end
 end
+
+@testset "term_order_key / qadd_order_key" begin
+    h = FockSpace(:c) ⊗ NLevelSpace(:atom, 2, 1)
+    a = Destroy(h, :a, 1)
+    σ = Transition(h, :σ, 1, 2, 2)
+
+    e1 = a' * a + 2.0 * a
+    e2 = 2.0 * a + a' * a   # same expression, different construction order
+    e3 = a' * a + 3.0 * a   # differs only in one coefficient
+    e4 = a' * σ             # different operators
+
+    @testset "construction-order independent (reproducible)" begin
+        @test isequal(e1, e2)
+        @test SecondQuantizedAlgebra.qadd_order_key(e1) == SecondQuantizedAlgebra.qadd_order_key(e2)
+    end
+
+    @testset "coefficient is a tiebreak (via _coeff_key)" begin
+        @test !isequal(e1, e3)
+        @test SecondQuantizedAlgebra.qadd_order_key(e1) != SecondQuantizedAlgebra.qadd_order_key(e3)
+        # _coeff_key distinguishes coefficients directly
+        c2 = SecondQuantizedAlgebra._to_cnum(2.0)
+        c3 = SecondQuantizedAlgebra._to_cnum(3.0)
+        @test SecondQuantizedAlgebra._coeff_key(c2) != SecondQuantizedAlgebra._coeff_key(c3)
+    end
+
+    qs = [e1, e3, e4, a * 1, (a' * a) * 1, σ * 1]
+
+    @testset "qadd_order_key ties exactly when isequal" begin
+        for x in qs, y in qs
+            @test (SecondQuantizedAlgebra.qadd_order_key(x) == SecondQuantizedAlgebra.qadd_order_key(y)) == isequal(x, y)
+        end
+    end
+
+    @testset "qadd_order_key is a strict total order (trichotomy)" begin
+        for x in qs, y in qs
+            kx, ky = SecondQuantizedAlgebra.qadd_order_key(x), SecondQuantizedAlgebra.qadd_order_key(y)
+            @test (kx < ky) + (ky < kx) + (kx == ky) == 1
+        end
+    end
+
+    @testset "term_order_key orders shorter products first" begin
+        t1 = first(keys((a * 1).arguments))         # length-1 product
+        t2 = first(keys(((a' * a) * 1).arguments))  # length-2 product
+        @test SecondQuantizedAlgebra.term_order_key(t1) < SecondQuantizedAlgebra.term_order_key(t2)
+    end
+end

--- a/test/order_key_test.jl
+++ b/test/order_key_test.jl
@@ -1,0 +1,61 @@
+using SecondQuantizedAlgebra
+using Test
+import SecondQuantizedAlgebra: QSym, Index, IndexedOperator
+
+# `order_key(op)` is the total, identity-faithful ordering key: a comparable tuple that
+# orders operators and ties two operators exactly when they are `isequal`.
+const order_key = SecondQuantizedAlgebra.order_key
+
+@testset "order_key" begin
+    # One product space exercising every concrete QSym subtype. Space indices:
+    # c=1 (Fock), atom=2 (NLevel), p=3 (Pauli), s=4 (Spin), q=5 (Phase).
+    h = FockSpace(:c) ⊗ NLevelSpace(:atom, 3, 1) ⊗ PauliSpace(:p) ⊗ SpinSpace(:s) ⊗ PhaseSpace(:q)
+    N = 4
+    ic = Index(h, :i, N, 1)
+    jc = Index(h, :j, N, 1)
+
+    a = Destroy(h, :a, 1)
+    ad = a'                      # Create, same site
+    b = Destroy(h, :b, 1)        # different name
+    ai = IndexedOperator(a, ic)  # indexed
+    aj = IndexedOperator(a, jc)  # different index name
+    σ12 = Transition(h, :σ, 1, 2, 2)
+    σ13 = Transition(h, :σ, 1, 3, 2)  # differs only in level j
+    px = Pauli(h, :σ, 1, 3)
+    py = Pauli(h, :σ, 2, 3)           # differs only in axis
+    Sx = Spin(h, :S, 1, 4)
+    Sy = Spin(h, :S, 2, 4)            # differs only in axis
+    x = Position(h, :x, 5)
+    p = Momentum(h, :p, 5)            # differs only in type from a Position-shaped key
+
+    ops = QSym[a, ad, b, ai, aj, σ12, σ13, px, py, Sx, Sy, x, p]
+
+    @testset "ties exactly when isequal" begin
+        for o1 in ops, o2 in ops
+            @test (order_key(o1) == order_key(o2)) == isequal(o1, o2)
+        end
+    end
+
+    @testset "distinguishes type-specific fields" begin
+        @test order_key(σ12) != order_key(σ13)  # levels
+        @test order_key(px) != order_key(py)    # axis
+        @test order_key(Sx) != order_key(Sy)    # axis
+        @test order_key(x) != order_key(p)      # Position vs Momentum
+        @test order_key(ai) != order_key(aj)    # index name
+    end
+
+    @testset "every concrete QSym subtype has a method" begin
+        for T in (Destroy, Create, Transition, Pauli, Spin, Position, Momentum)
+            @test hasmethod(order_key, Tuple{T})
+            # a dedicated method, not the generic QSym fallback (which would drop fields)
+            @test which(order_key, Tuple{T}).sig !== Tuple{typeof(order_key), QSym}
+        end
+    end
+
+    @testset "is a strict total order (trichotomy)" begin
+        for o1 in ops, o2 in ops
+            k1, k2 = order_key(o1), order_key(o2)
+            @test (k1 < k2) + (k2 < k1) + (k1 == k2) == 1
+        end
+    end
+end


### PR DESCRIPTION
## What

Adds three public functions for a **total, identity-faithful structural ordering** of operators, products, and sums:

- `order_key(op::QSym)` — one method per concrete subtype (`Destroy`, `Create`, `Transition`, `Pauli`, `Spin`, `Position`, `Momentum`), co-located with each type's `isequal`/`hash`. **No generic `QSym` fallback**, so a new operator type added without a key is a loud `MethodError`, not a silent field-dropping collision.
- `term_order_key(t::QTerm)` and `qadd_order_key(q::QAdd)` — built from `order_key`; two `QAdd`s compare with `<` on their keys.

## Why

The contract is `order_key(a) == order_key(b)` iff `isequal(a, b)`: a strict total order that never ties distinct operators. This gives downstream packages (QuantumCumulants.jl) a reproducible way to pick canonical representatives and compare expressions, replacing hand-rolled, incomplete keys and `show`-based round-trips.