### PR TITLE
feat!: to_numeric returns a concrete (sparse) operator by default

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,11 +5,11 @@ All notable changes to [`SecondQuantizedAlgebra.jl`](https://github.com/qojulia/
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v0.10.0]
+## [v0.9.2]
 
 ### Changed
 
-- **Breaking:** `to_numeric` now returns a concrete operator by default, and its representation depends only on `op_type`, not on the shape of the expression. Previously a bare operator translated to a `LazyTensor` and a sum to a `LazySum` (via the positional path), while the keyword path materialized `sparse` only in some branches, so composing subexpressions silently changed the return type and operators handed to solvers were lazy by default. The default `op_type` is now `sparse` (was `identity`), applied uniformly to bare operators, products, and sums. Pass `op_type=dense` for a dense operator, or `op_type=identity` to opt into the natural lazy representation (`LazyTensor`/`LazyProduct`/`LazySum`) for large tensor-product spaces where an operator is local to a few subsystems. The lazy embedding is kept internal, so a term is still assembled from lazy factors and materialized exactly once. Code relying on the previous lazy default must now pass `op_type=identity`.
+- `to_numeric` now returns a concrete operator by default, and its representation depends only on `op_type`, not on the shape of the expression. Previously a bare operator translated to a `LazyTensor` and a sum to a `LazySum` (via the positional path), while the keyword path materialized `sparse` only in some branches, so composing subexpressions silently changed the return type and operators handed to solvers were lazy by default. The default `op_type` is now `sparse` (was `identity`), applied uniformly to bare operators, products, and sums. Pass `op_type=dense` for a dense operator, or `op_type=identity` to opt into the natural lazy representation (`LazyTensor`/`LazyProduct`/`LazySum`) for large tensor-product spaces where an operator is local to a few subsystems. The lazy embedding is kept internal, so a term is still assembled from lazy factors and materialized exactly once. Code relying on the previous lazy default must now pass `op_type=identity`.
 
 ## [v0.9.1]
 
@@ -268,4 +268,5 @@ These names keep their meaning across the migration. Code that only uses them sh
 [v0.8.3]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/releases/tag/v0.8.3
 [v0.9.0]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/releases/tag/v0.9.0
 [v0.9.1]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/releases/tag/v0.9.1
+[v0.9.2]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/releases/tag/v0.9.2
 [#156]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/issues/156

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,12 @@ All notable changes to [`SecondQuantizedAlgebra.jl`](https://github.com/qojulia/
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.10.0]
+
+### Changed
+
+- **Breaking:** `to_numeric` now returns a concrete operator by default, and its representation depends only on `op_type`, not on the shape of the expression. Previously a bare operator translated to a `LazyTensor` and a sum to a `LazySum` (via the positional path), while the keyword path materialized `sparse` only in some branches, so composing subexpressions silently changed the return type and operators handed to solvers were lazy by default. The default `op_type` is now `sparse` (was `identity`), applied uniformly to bare operators, products, and sums. Pass `op_type=dense` for a dense operator, or `op_type=identity` to opt into the natural lazy representation (`LazyTensor`/`LazyProduct`/`LazySum`) for large tensor-product spaces where an operator is local to a few subsystems. The lazy embedding is kept internal, so a term is still assembled from lazy factors and materialized exactly once. Code relying on the previous lazy default must now pass `op_type=identity`.
+
 ## [v0.9.1]
 
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SecondQuantizedAlgebra"
 uuid = "f7aa4685-e143-4cb6-a7f3-073579757907"
-version = "0.10.0"
+version = "0.9.2"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SecondQuantizedAlgebra"
 uuid = "f7aa4685-e143-4cb6-a7f3-073579757907"
-version = "0.9.1"
+version = "0.10.0"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/docs/src/devdocs.md
+++ b/docs/src/devdocs.md
@@ -378,14 +378,22 @@ The scope rides as a `SumScope` *argument* of the `Term`, not as metadata, becau
 
 ## Numeric conversion
 
-`to_numeric` maps symbolic operators to QuantumOpticsBase matrices:
+`to_numeric` maps symbolic operators to QuantumOpticsBase matrices. A term is
+assembled in a natural lazy representation and materialized to a concrete
+operator exactly once, at the top, via `op_type` (default `sparse`). This keeps
+the return type independent of the shape of the expression (a bare operator, a
+product, and a sum all return the same `op_type`), while still avoiding
+per-factor conversions during assembly.
 
-- **Simple basis:** Direct dispatch — `Destroy → destroy(b)`, `Transition → transition(b, i, j)`, etc.
-- **Composite basis:** Embeds the single-site matrix as a `LazyTensor`:
+- **Simple basis:** Direct dispatch, e.g. `Destroy → destroy(b)`, `Transition → transition(b, i, j)`.
+- **Composite basis:** The internal `_embed` embeds the single-site matrix as a `LazyTensor`:
   ```julia
-  op_num = to_numeric(op, b.bases[idx])
+  op_num = _embed(op, b.bases[idx])
   LazyTensor(b, [idx], (op_num,))
   ```
+  `_embed` is the composable building block for products and sums. The public
+  `to_numeric` methods wrap the assembled result in `op_type`, so the positional
+  forms return `sparse` and `op_type=identity` returns the lazy form as-is.
 
 **`_to_number`** extracts plain Julia numbers from `Num`/`CNum` wrappers for numeric evaluation. Falls back to the symbolic value if it can't be unwrapped (for symbolic prefactors that haven't been substituted yet).
 

--- a/docs/src/implementation.md
+++ b/docs/src/implementation.md
@@ -265,7 +265,7 @@ nothing # hide
 
 ### Composite systems
 
-For product spaces, [`to_numeric`](@ref) returns `LazyTensor` operators, which efficiently handle large tensor products:
+For product spaces, [`to_numeric`](@ref) returns a concrete `sparse` operator by default, independent of the shape of the expression. Pass `op_type=identity` to get the `LazyTensor`/`LazySum` representation instead, which avoids materializing the full Kronecker product and is preferable for large tensor products where an operator is local to a few subsystems:
 
 ```@example numeric-composite
 using SecondQuantizedAlgebra, QuantumOpticsBase
@@ -280,7 +280,8 @@ bf = FockBasis(10)
 bn = NLevelBasis(3)
 bc = bf ⊗ bn
 
-a_num = to_numeric(a, bc)
+a_num = to_numeric(a, bc)                      # sparse Operator (default)
+a_lazy = to_numeric(a, bc; op_type = identity) # LazyTensor
 s_num = to_numeric(s(:a, :c), bc)
 nothing # hide
 ```

--- a/src/numeric.jl
+++ b/src/numeric.jl
@@ -7,7 +7,7 @@ const _NO_SUBS = Dict{QSym, Union{}}()
     to_numeric(op, basis [, d::AbstractDict{<:QSym}])
     to_numeric(op, state [, d::AbstractDict{<:QSym}])
     to_numeric(op, basis; parameter=Dict(), time_parameter=Dict(), operators=Dict(),
-               adjoint_ops=true, op_type=identity)
+               adjoint_ops=true, op_type=sparse)
     to_numeric(ops::AbstractVector, basis; kwargs...)
 
 Convert a symbolic operator expression to a numeric QuantumOpticsBase operator.
@@ -18,6 +18,23 @@ The keyword form first substitutes scalar `parameter`s, then translates using
 custom numeric `operators`. Missing adjoint entries are added to `operators`
 when `adjoint_ops=true`. If `time_parameter` is non-empty, values may be numbers
 or functions of time and the result is a closure `t -> op(t)`.
+
+The result representation is controlled by `op_type` and does not depend on the
+shape of the expression: a bare operator, a product, and a sum all return the
+same operator type. `op_type` is applied once to the assembled operator:
+
+  - `op_type=sparse` (default): a sparse `Operator`. A good general default: it
+    is memory-scalable, type-stable, and the form the QuantumOptics solvers
+    consume most efficiently.
+  - `op_type=dense`: a dense `Operator`. Prefer for small Hilbert spaces.
+  - `op_type=identity`: the natural lazy representation (`LazyTensor` /
+    `LazyProduct` / `LazySum`). Opt in for large tensor-product spaces where an
+    operator is local to a few subsystems, so the full Kronecker product is
+    never materialised. (In the time-dependent path with more than one term,
+    terms are still materialised to keep the returned closure type-stable.)
+
+The positional forms `to_numeric(op, basis[, d])` always return `sparse`; use
+the keyword form to select `dense` or `identity`.
 
 # Examples
 
@@ -80,19 +97,37 @@ function to_numeric(op::Op, b::QuantumOpticsBase.SpinBasis)
     end
     throw(ArgumentError("Op kind $(op.kind) does not act on a SpinBasis"))
 end
-function to_numeric(op::Op, b::QuantumOpticsBase.CompositeBasis)
+# ── Internal lazy embedding ─────────────────────────────────────────────────
+# `_embed` builds the natural lazy representation of a single operator on `b`
+# (a `LazyTensor` on a `CompositeBasis`). It is the composable building block for
+# products and sums; the public `to_numeric` methods materialise the assembled
+# result via `op_type` (sparse by default). Keeping the embedding lazy lets a
+# whole term be assembled as lazy factors and converted to a concrete operator
+# exactly once, at the top.
+_embed(op::Op, b::QuantumOpticsBase.Basis) = to_numeric(op, b)
+function _embed(op::Op, b::QuantumOpticsBase.CompositeBasis)
     si = Int(op.space_index)
-    return QuantumOpticsBase.LazyTensor(b, [si], (to_numeric(op, b.bases[si]),))
+    return QuantumOpticsBase.LazyTensor(b, [si], (_embed(op, b.bases[si]),))
 end
-
-function to_numeric(op::Op, b::QuantumOpticsBase.Basis, d::AbstractDict{<:QSym})
+function _embed(op::Op, b::QuantumOpticsBase.Basis, d::AbstractDict{<:QSym})
     haskey(d, op) && return d[op]
-    return to_numeric(op, b)
+    return _embed(op, b)
 end
 
+# Public positional forms return a concrete sparse operator, independent of
+# expression shape. To choose the representation (`dense`, or `identity` for the
+# lazy form) use the keyword form `to_numeric(op, b; op_type=...)`.
+to_numeric(op::Op, b::QuantumOpticsBase.CompositeBasis) =
+    QuantumOpticsBase.sparse(_embed(op, b))
+to_numeric(op::Op, b::QuantumOpticsBase.Basis, d::AbstractDict{<:QSym}) =
+    QuantumOpticsBase.sparse(_embed(op, b, d))
+to_numeric(s::QAdd, b::QuantumOpticsBase.Basis, d::AbstractDict{<:QSym} = _NO_SUBS) =
+    QuantumOpticsBase.sparse(_assemble(s, b, d))
+
+# Natural (lazy) assembly of an operator sum; the caller materialises it.
 # Scalar-term and operator-product branches return different operator types
 # (Diagonal identity vs SparseMatrixCSC), so the conditional stays in-loop.
-function to_numeric(s::QAdd, b::QuantumOpticsBase.Basis, d::AbstractDict{<:QSym} = _NO_SUBS)
+function _assemble(s::QAdd, b::QuantumOpticsBase.Basis, d::AbstractDict{<:QSym} = _NO_SUBS)
     iter = iterate(s.arguments)
     iter === nothing && return _to_complex(_CNUM_ZERO) * _lazy_one(b)
     (term, c), st = iter
@@ -107,9 +142,9 @@ function to_numeric(s::QAdd, b::QuantumOpticsBase.Basis, d::AbstractDict{<:QSym}
 end
 
 function _product(ops::Vector{Op}, b::QuantumOpticsBase.Basis, d::AbstractDict{<:QSym} = _NO_SUBS)
-    acc = to_numeric(first(ops), b, d)
+    acc = _embed(first(ops), b, d)
     for i in 2:length(ops)
-        acc *= to_numeric(ops[i], b, d)
+        acc *= _embed(ops[i], b, d)
     end
     return acc
 end
@@ -121,7 +156,7 @@ function _to_numeric_kw(
         time_parameter = Dict(),
         operators = Dict{QSym, Any}(),
         adjoint_ops = true,
-        op_type = identity,
+        op_type = QuantumOpticsBase.sparse,
     )
     param = _expand_parameter(parameter)
     tp = _normalize_time_parameter(time_parameter)
@@ -257,7 +292,7 @@ function _to_numeric_static(
 end
 
 _to_numeric_with_ops(op, b::QuantumOpticsBase.Basis, operators::AbstractDict{<:QSym}) =
-    isempty(operators) ? to_numeric(op, b) : to_numeric(op, b, operators)
+    isempty(operators) ? _embed(op, b) : _embed(op, b, operators)
 
 function _numeric_product(
         ops::Vector{Op},
@@ -444,7 +479,7 @@ function to_numeric(
             result, term, c, q.indices, b, sites, d, sub_re, sub_im, has_imag,
         )
     end
-    return result
+    return QuantumOpticsBase.sparse(result)
 end
 
 function _accumulate_indexed_term!(
@@ -588,7 +623,7 @@ function _resolve_slot(op::QSym, sites::AbstractDict{Int, Vector{Int}})
     )
 end
 
-to_numeric(x::Number, b::QuantumOpticsBase.Basis, ::AbstractDict{<:QSym} = _NO_SUBS) = _to_complex(x) * _lazy_one(b)
+to_numeric(x::Number, b::QuantumOpticsBase.Basis, ::AbstractDict{<:QSym} = _NO_SUBS) = QuantumOpticsBase.sparse(_to_complex(x) * _lazy_one(b))
 to_numeric(op::QField, state::QuantumState, d::AbstractDict{<:QSym} = _NO_SUBS) = to_numeric(op, QuantumOpticsBase.basis(state), d)
 to_numeric(x::Number, state::QuantumState) = to_numeric(x, QuantumOpticsBase.basis(state))
 

--- a/src/numeric.jl
+++ b/src/numeric.jl
@@ -149,6 +149,15 @@ function _product(ops::Vector{Op}, b::QuantumOpticsBase.Basis, d::AbstractDict{<
     return acc
 end
 
+# Lazy (un-materialised) numeric form. Used where the consumer contracts the
+# operator with a state immediately and therefore never needs a concrete matrix,
+# e.g. `expect` against a `LazyKet` (which has no `expect` method for a sparse
+# operator, and whose whole purpose is to avoid materialising the Kronecker
+# product). Mirrors the positional `to_numeric(op, b, d)` dispatch, minus the
+# final `sparse`.
+_to_numeric_lazy(op::Op, b::QuantumOpticsBase.Basis, d::AbstractDict{<:QSym}) = _embed(op, b, d)
+_to_numeric_lazy(s::QAdd, b::QuantumOpticsBase.Basis, d::AbstractDict{<:QSym}) = _assemble(s, b, d)
+
 function _to_numeric_kw(
         op,
         b::QuantumOpticsBase.Basis;
@@ -732,7 +741,7 @@ function numeric_average(op, states::AbstractVector, d::AbstractDict{<:QSym} = _
     return _numeric_average_vec(op, states, d)
 end
 
-_numeric_average(op::QField, state::QuantumState, d::AbstractDict{<:QSym}) = ComplexF64(QuantumOpticsBase.expect(to_numeric(op, state, d), state))
+_numeric_average(op::QField, state::QuantumState, d::AbstractDict{<:QSym}) = ComplexF64(QuantumOpticsBase.expect(_to_numeric_lazy(op, QuantumOpticsBase.basis(state), d), state))
 _numeric_average(x::Number, ::QuantumState, ::AbstractDict{<:QSym}) = _to_complex(x)
 _numeric_average(x::Num, state::QuantumState, d::AbstractDict{<:QSym}) = _numeric_average(SymbolicUtils.unwrap(x), state, d)
 

--- a/src/numeric.jl
+++ b/src/numeric.jl
@@ -97,13 +97,7 @@ function to_numeric(op::Op, b::QuantumOpticsBase.SpinBasis)
     end
     throw(ArgumentError("Op kind $(op.kind) does not act on a SpinBasis"))
 end
-# ── Internal lazy embedding ─────────────────────────────────────────────────
-# `_embed` builds the natural lazy representation of a single operator on `b`
-# (a `LazyTensor` on a `CompositeBasis`). It is the composable building block for
-# products and sums; the public `to_numeric` methods materialise the assembled
-# result via `op_type` (sparse by default). Keeping the embedding lazy lets a
-# whole term be assembled as lazy factors and converted to a concrete operator
-# exactly once, at the top.
+# Lazy embedding of a single operator on `b`; building block for products/sums.
 _embed(op::Op, b::QuantumOpticsBase.Basis) = to_numeric(op, b)
 function _embed(op::Op, b::QuantumOpticsBase.CompositeBasis)
     si = Int(op.space_index)
@@ -114,9 +108,7 @@ function _embed(op::Op, b::QuantumOpticsBase.Basis, d::AbstractDict{<:QSym})
     return _embed(op, b)
 end
 
-# Public positional forms return a concrete sparse operator, independent of
-# expression shape. To choose the representation (`dense`, or `identity` for the
-# lazy form) use the keyword form `to_numeric(op, b; op_type=...)`.
+# Positional forms materialise sparse; use the keyword form for other `op_type`.
 to_numeric(op::Op, b::QuantumOpticsBase.CompositeBasis) =
     QuantumOpticsBase.sparse(_embed(op, b))
 to_numeric(op::Op, b::QuantumOpticsBase.Basis, d::AbstractDict{<:QSym}) =
@@ -124,9 +116,7 @@ to_numeric(op::Op, b::QuantumOpticsBase.Basis, d::AbstractDict{<:QSym}) =
 to_numeric(s::QAdd, b::QuantumOpticsBase.Basis, d::AbstractDict{<:QSym} = _NO_SUBS) =
     QuantumOpticsBase.sparse(_assemble(s, b, d))
 
-# Natural (lazy) assembly of an operator sum; the caller materialises it.
-# Scalar-term and operator-product branches return different operator types
-# (Diagonal identity vs SparseMatrixCSC), so the conditional stays in-loop.
+# Lazy assembly of an operator sum; the caller materialises it.
 function _assemble(s::QAdd, b::QuantumOpticsBase.Basis, d::AbstractDict{<:QSym} = _NO_SUBS)
     iter = iterate(s.arguments)
     iter === nothing && return _to_complex(_CNUM_ZERO) * _lazy_one(b)
@@ -149,12 +139,7 @@ function _product(ops::Vector{Op}, b::QuantumOpticsBase.Basis, d::AbstractDict{<
     return acc
 end
 
-# Lazy (un-materialised) numeric form. Used where the consumer contracts the
-# operator with a state immediately and therefore never needs a concrete matrix,
-# e.g. `expect` against a `LazyKet` (which has no `expect` method for a sparse
-# operator, and whose whole purpose is to avoid materialising the Kronecker
-# product). Mirrors the positional `to_numeric(op, b, d)` dispatch, minus the
-# final `sparse`.
+# Lazy form for consumers that contract immediately (e.g. `expect` on a `LazyKet`).
 _to_numeric_lazy(op::Op, b::QuantumOpticsBase.Basis, d::AbstractDict{<:QSym}) = _embed(op, b, d)
 _to_numeric_lazy(s::QAdd, b::QuantumOpticsBase.Basis, d::AbstractDict{<:QSym}) = _assemble(s, b, d)
 

--- a/test/numeric_test.jl
+++ b/test/numeric_test.jl
@@ -44,8 +44,6 @@ using Test
         @qnumbers a1::Destroy(h, 1) a2::Destroy(h, 2)
         b = FockBasis(3) ⊗ FockBasis(3)
 
-        # Default materialises to a concrete sparse operator; the lazy
-        # representation is opt-in via `op_type = identity`.
         a1_lazy = to_numeric(a1, b; op_type = identity)
         @test a1_lazy isa LazyTensor
         a1_num = to_numeric(a1, b)
@@ -214,7 +212,6 @@ using Test
                 [1, 3],
                 (create(bfock), QuantumOpticsBase.transition(bnlevel, i, j)),
             )
-            # Default returns the same operator, materialised sparse.
             @test to_numeric(op1, bprod_gap) == sparse(
                 to_numeric(op1, bprod_gap; op_type = identity),
             )
@@ -260,9 +257,7 @@ using Test
     end
 
     @testset "numeric_average — LazyKet state" begin
-        # `numeric_average` must contract against a lazy operator here: `expect`
-        # has no method for a sparse operator paired with a `LazyKet`, and a
-        # `LazyKet` exists precisely to avoid materialising the full state.
+        # `expect` has no method for a sparse operator paired with a `LazyKet`.
         hfock = FockSpace(:fock)
         hnlevel = NLevelSpace(:nlevel, (:a, :b, :c))
         hprod = hfock ⊗ hnlevel
@@ -283,7 +278,6 @@ using Test
             op_num = to_numeric(op, bprod)
             @test numeric_average(op, ψ_lazy) ≈ expect(op_num, ψ_dense)
         end
-        # average-expression entry point (undo_average path) on a LazyKet
         @test numeric_average(average(a' * a), ψ_lazy) ≈
             expect(to_numeric(a' * a, bprod), ψ_dense)
     end
@@ -619,23 +613,19 @@ using Test
     end
 
     @testset "op_type is shape-independent" begin
-        # A bare operator, a product, and a sum must all return the same
-        # operator type for a given op_type — the representation depends only on
-        # op_type, never on the shape of the expression.
+        # The return type depends only on op_type, not on the expression shape.
         h = FockSpace(:a) ⊗ FockSpace(:b)
         @qnumbers a1::Destroy(h, 1) a2::Destroy(h, 2)
         b = FockBasis(3) ⊗ FockBasis(3)
         exprs = (a1, a1' * a1, a1' * a1 + a2' * a2)
 
         for expr in exprs
-            @test to_numeric(expr, b) isa Operator                     # sparse default
+            @test to_numeric(expr, b) isa Operator
             @test to_numeric(expr, b) == to_numeric(expr, b; op_type = sparse)
             @test to_numeric(expr, b; op_type = dense) isa Operator
         end
-        # The lazy opt-in yields lazy types across every shape.
         @test to_numeric(exprs[1], b; op_type = identity) isa LazyTensor
         @test to_numeric(exprs[3], b; op_type = identity) isa LazySum
-        # Values agree across representations.
         for expr in exprs
             @test to_numeric(expr, b) == sparse(to_numeric(expr, b; op_type = identity))
             @test dense(to_numeric(expr, b)) ≈ dense(to_numeric(expr, b; op_type = dense))

--- a/test/numeric_test.jl
+++ b/test/numeric_test.jl
@@ -259,6 +259,35 @@ using Test
         end
     end
 
+    @testset "numeric_average — LazyKet state" begin
+        # `numeric_average` must contract against a lazy operator here: `expect`
+        # has no method for a sparse operator paired with a `LazyKet`, and a
+        # `LazyKet` exists precisely to avoid materialising the full state.
+        hfock = FockSpace(:fock)
+        hnlevel = NLevelSpace(:nlevel, (:a, :b, :c))
+        hprod = hfock ⊗ hnlevel
+        bfock = FockBasis(10)
+        bnlevel = NLevelBasis(3)
+        bprod = bfock ⊗ bnlevel
+
+        @qnumbers a::Destroy(hprod, 1)
+        σ(i, j) = Transition(hprod, :σ, i, j, 2)
+
+        α = 0.3 + 0.0im
+        ket_fock = coherentstate(bfock, α)
+        ket_nlevel = (nlevelstate(bnlevel, 1) + nlevelstate(bnlevel, 3)) / sqrt(2)
+        ψ_lazy = LazyKet(bprod, (ket_fock, ket_nlevel))
+        ψ_dense = ket_fock ⊗ ket_nlevel
+
+        for op in (a, a' * σ(:a, :c), a + a' * σ(:a, :c))
+            op_num = to_numeric(op, bprod)
+            @test numeric_average(op, ψ_lazy) ≈ expect(op_num, ψ_dense)
+        end
+        # average-expression entry point (undo_average path) on a LazyKet
+        @test numeric_average(average(a' * a), ψ_lazy) ≈
+            expect(to_numeric(a' * a, bprod), ψ_dense)
+    end
+
     @testset "numeric_average — comprehensive expressions" begin
         h = FockSpace(:fock)
         @qnumbers a::Destroy(h)

--- a/test/numeric_test.jl
+++ b/test/numeric_test.jl
@@ -44,8 +44,14 @@ using Test
         @qnumbers a1::Destroy(h, 1) a2::Destroy(h, 2)
         b = FockBasis(3) ⊗ FockBasis(3)
 
+        # Default materialises to a concrete sparse operator; the lazy
+        # representation is opt-in via `op_type = identity`.
+        a1_lazy = to_numeric(a1, b; op_type = identity)
+        @test a1_lazy isa LazyTensor
         a1_num = to_numeric(a1, b)
-        @test a1_num isa LazyTensor
+        @test a1_num isa Operator
+        @test a1_num == sparse(a1_lazy)
+        @test to_numeric(a1, b; op_type = dense) == dense(a1_lazy)
     end
 
     @testset "numeric_average" begin
@@ -96,7 +102,8 @@ using Test
         bf = FockBasis(3)
         bn = NLevelBasis(3)
         bc = bf ⊗ bn
-        @test to_numeric(σ12, bc) isa LazyTensor
+        @test to_numeric(σ12, bc; op_type = identity) isa LazyTensor
+        @test to_numeric(σ12, bc) isa Operator
     end
 
     @testset "Type stability" begin
@@ -197,15 +204,19 @@ using Test
             i == j == 1 && continue
             op1 = a * σprod_gap(i, j)
             op2 = a' * σprod_gap(i, j)
-            @test to_numeric(op1, bprod_gap) == LazyTensor(
+            @test to_numeric(op1, bprod_gap; op_type = identity) == LazyTensor(
                 bprod_gap,
                 [1, 3],
                 (destroy(bfock), QuantumOpticsBase.transition(bnlevel, i, j)),
             )
-            @test to_numeric(op2, bprod_gap) == LazyTensor(
+            @test to_numeric(op2, bprod_gap; op_type = identity) == LazyTensor(
                 bprod_gap,
                 [1, 3],
                 (create(bfock), QuantumOpticsBase.transition(bnlevel, i, j)),
+            )
+            # Default returns the same operator, materialised sparse.
+            @test to_numeric(op1, bprod_gap) == sparse(
+                to_numeric(op1, bprod_gap; op_type = identity),
             )
         end
     end
@@ -576,6 +587,30 @@ using Test
         @test_throws ArgumentError to_numeric(
             x * E * a, b; time_parameter = Dict(E => t -> 1.0 + 0im),
         )                                                                       # untimed variable
+    end
+
+    @testset "op_type is shape-independent" begin
+        # A bare operator, a product, and a sum must all return the same
+        # operator type for a given op_type — the representation depends only on
+        # op_type, never on the shape of the expression.
+        h = FockSpace(:a) ⊗ FockSpace(:b)
+        @qnumbers a1::Destroy(h, 1) a2::Destroy(h, 2)
+        b = FockBasis(3) ⊗ FockBasis(3)
+        exprs = (a1, a1' * a1, a1' * a1 + a2' * a2)
+
+        for expr in exprs
+            @test to_numeric(expr, b) isa Operator                     # sparse default
+            @test to_numeric(expr, b) == to_numeric(expr, b; op_type = sparse)
+            @test to_numeric(expr, b; op_type = dense) isa Operator
+        end
+        # The lazy opt-in yields lazy types across every shape.
+        @test to_numeric(exprs[1], b; op_type = identity) isa LazyTensor
+        @test to_numeric(exprs[3], b; op_type = identity) isa LazySum
+        # Values agree across representations.
+        for expr in exprs
+            @test to_numeric(expr, b) == sparse(to_numeric(expr, b; op_type = identity))
+            @test dense(to_numeric(expr, b)) ≈ dense(to_numeric(expr, b; op_type = dense))
+        end
     end
 
 end

--- a/test/operators/phase_space_test.jl
+++ b/test/operators/phase_space_test.jl
@@ -142,7 +142,8 @@ import SecondQuantizedAlgebra: simplify, QAdd, QSym, HilbertSpace
         bf = FockBasis(3)
         bq = FockBasis(5)
         bc = bf ⊗ bq
-        @test to_numeric(x, bc) isa LazyTensor
+        @test to_numeric(x, bc; op_type = identity) isa LazyTensor
+        @test to_numeric(x, bc) isa Operator
     end
 
     @testset "Printing" begin


### PR DESCRIPTION

`to_numeric`'s return representation currently depends on the *shape* of the expression, not on what the caller asked for:

- `to_numeric(a, b)` (bare operator) → `LazyTensor`
- `to_numeric(a'a + b'b, b)` (sum) → `LazySum`
- the keyword path materialises `sparse` only in some branches

So composing subexpressions silently changes the return type, generic downstream code isn't type-stable, and operators handed to QuantumOptics solvers are lazy by default. Downstream (QuantumInputOutput.jl) this surfaced as a ~2.9x slowdown in a two-time correlation benchmark: the hot ODE loop was multiplying `LazyTensor`/`LazySum` operators instead of sparse matrices.


Make the representation depend only on `op_type`, applied once to the assembled operator, uniformly across bare operators, products, and sums:

| `op_type` | result |
|-|-|
| `sparse` (**new default**) | sparse `Operator`, solver-friendly, type-stable, scales |
| `dense` | dense `Operator`, small Hilbert spaces |
| `identity` | natural lazy form (`LazyTensor`/`LazyProduct`/`LazySum`), opt-in for large tensor-product spaces where an operator is local to a few subsystems |

The lazy embedding is kept as an internal primitive (`_embed`), so a term is still assembled from lazy factors and materialised exactly once at the top, with no per-factor conversion overhead.
