### PR TITLE
Fix: diagonal coefficient leak for coefficient-only summation indices

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,12 @@ All notable changes to [`SecondQuantizedAlgebra.jl`](https://github.com/qojulia/
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.9.3]
+
+### Fixed
+
+- The diagonal split in `_accumulate_with_diag!` no longer leaks the diagonal coefficient into the off-diagonal body when a summation index appears only in a term's coefficient. Multiplying a sum such as `Σ_k u(l,k)·σ_l` by an operator peels off the diagonal `k = l` slice, but the substitution dropped the split's `k ≠ l` constraint instead of rewriting it onto the collapsed index. A sibling scope then re-admitted `k = l`, so the off-diagonal body's coefficient became `u(l,k) + u(l,l)` and the diagonal was over-counted (for example `commutator(σ_l^{22}, Σ_{j,k} u(j,k)(σ_j^{21}+σ_j^{12}))` gained a spurious `u(l,l)` in every `Σ_k` term). The diagonal contribution now rewrites each `sum_idx ≠ β` constraint onto `ext_idx`, exactly as the `Σ` diagonal split already does, so the off-diagonal body keeps its bare coefficient and the diagonal is emitted once. This is the SecondQuantizedAlgebra half of QuantumCumulants issue [#198](https://github.com/qojulia/QuantumCumulants.jl/issues/198).
+
 ## [v0.9.2]
 
 ### Changed

--- a/Changelog.md
+++ b/Changelog.md
@@ -275,4 +275,5 @@ These names keep their meaning across the migration. Code that only uses them sh
 [v0.9.0]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/releases/tag/v0.9.0
 [v0.9.1]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/releases/tag/v0.9.1
 [v0.9.2]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/releases/tag/v0.9.2
+[v0.9.3]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/releases/tag/v0.9.3
 [#156]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/issues/156

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SecondQuantizedAlgebra"
 uuid = "f7aa4685-e143-4cb6-a7f3-073579757907"
-version = "0.9.2"
+version = "0.9.3"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/algebra/pipelines.jl
+++ b/src/algebra/pipelines.jl
@@ -85,7 +85,8 @@ end
 When summing over indices that may coincide with another operator's index, emit
 both the off-diagonal contribution (under `ne ∪ {(sum_idx, ext_idx)}` enforcing
 the indices differ) and each diagonal contribution (substituting
-`sum_idx -> ext_idx`, under `ne` with any constraint on `sum_idx` dropped).
+`sum_idx -> ext_idx`, with each constraint on `sum_idx` rewritten onto
+`ext_idx`, mirroring the diagonal split in [`Σ`](@ref)).
 """
 function _accumulate_with_diag!(
         out::QTermDict, ops::Vector{Op}, c::CNum,
@@ -131,7 +132,13 @@ function _accumulate_with_diag!(
     for (sum_idx, ext_idx) in diag_pairs
         sub_ops = Op[change_index(o, sum_idx, ext_idx) for o in ops]
         sub_c = change_index(c, sum_idx, ext_idx)
-        sub_ne = _drop_ne_with(ne, sum_idx)
+        # Rewrite (not drop) the collapsed index in the constraints: a
+        # `sum_idx ≠ β` becomes `ext_idx ≠ β` on the diagonal, exactly as the
+        # `Σ` diagonal split does. Dropping it lets a sibling sum index re-admit
+        # the excluded value: a coefficient-only-index term `Σ_k u(l,k)·σ_l`
+        # (constraint k≠l from the off-diagonal split) would otherwise merge
+        # with a genuine diagonal `u(l,l)·σ_l` under the same key and over-count.
+        sub_ne = _substitute_ne(ne, sum_idx, ext_idx)
         # Sibling diagonal slices for the same sum must be mutually exclusive;
         # without ext_idx ≠ other_ext, the i=j and i=k branches both contain
         # i=j=k and the canonical sort cannot collapse same-index operators

--- a/src/expressions/qterm.jl
+++ b/src/expressions/qterm.jl
@@ -127,17 +127,6 @@ function _substitute_ne(ne::Vector{NonEqualPair}, pairs::AbstractDict{Index, Ind
     return isempty(out) ? _EMPTY_NE : out
 end
 
-function _drop_ne_with(ne::Vector{NonEqualPair}, idx::Index)
-    isempty(ne) && return _EMPTY_NE
-    out = NonEqualPair[]
-    for (α, β) in ne
-        α == idx && continue
-        β == idx && continue
-        _push_ne_unique!(out, (α, β))
-    end
-    return isempty(out) ? _EMPTY_NE : out
-end
-
 function _copy_key(term::QTerm)
     return QTerm(copy(term.ops), _copy_ne(term.ne), term.hash)
 end

--- a/test/canonical_models_test.jl
+++ b/test/canonical_models_test.jl
@@ -93,6 +93,34 @@ import SecondQuantizedAlgebra: QAdd, Index, simplify
         end
     end
 
+    @testset "coefficient-only summation index: no diagonal leak into off-diagonal body" begin
+        # A per-site drive Ω_l = Σ_k u(l,k) built from a DoubleIndexedVariable carries the
+        # summation index `k` ONLY in the coefficient; no operator carries it. Multiplying
+        # such a sum by an operator triggers the diagonal split, which must keep the
+        # off-diagonal body's coefficient bare (`u(l,k)`) and emit the diagonal `k=l`
+        # contribution as a SEPARATE `u(l,l)` term. Pen-and-paper: only j=l survives
+        # [σ_l^{22}, Σ_{j,k} u(j,k)(σ_j^{21}+σ_j^{12})], splitting the inner sum as
+        # Σ_k u(l,k) = u(l,l) + Σ_{k≠l} u(l,k).
+        k = Index(h, :k, N, ha)
+        l = Index(h, :l, N, ha)
+        u(α, β) = DoubleIndexedVariable(:u, α, β)
+        Hdrive = Σ(Σ(u(j, k) * (σ(2, 1, j) + σ(1, 2, j)), j), k)
+        expected = u(l, l) * σ(2, 1, l) - u(l, l) * σ(1, 2, l) +
+            Σ(u(l, k) * σ(2, 1, l) - u(l, k) * σ(1, 2, l), k, Index[l])
+        @test commutator(σ(2, 2, l), Hdrive) == expected
+
+        # Structural regression for the leak: no term may carry a `k`-dependent coefficient
+        # without the `k≠l` constraint. Before the fix the diagonal substitution dropped
+        # `k≠l`, so a sibling scope re-admitted `k=l` and the off-diagonal body's coefficient
+        # became `u(l,k)+u(l,l)`, over-counting the diagonal.
+        comm = commutator(σ(2, 2, l), Hdrive)
+        for (term, c) in comm.arguments
+            if SecondQuantizedAlgebra._depends_on_index_term(c, term.ops, k)
+                @test SecondQuantizedAlgebra._ne_contains(term.ne, k, l)
+            end
+        end
+    end
+
 end
 
 @testset "Dicke model commutators" begin


### PR DESCRIPTION
Found this while chasing qojulia/QuantumCumulants.jl#198.

If a summation index only shows up in a term's coefficient (say a per-site drive `Ω_l = Σ_k u(l,k)` from a `DoubleIndexedVariable`), multiplying that sum by an operator hits the diagonal split in `_accumulate_with_diag!`. The split correctly peels off the `k = l` slice, but on the diagonal substitution it was calling `_drop_ne_with`, throwing away the `k ≠ l` constraint instead of moving it onto the surviving index. With that constraint gone a sibling scope re-admits `k = l`, and the off-diagonal coefficient ends up as `u(l,k) + u(l,l)`, so the diagonal gets counted twice.

Before:

```
commutator(σ_l²², Σ_{j,k} u(j,k)(σ_j²¹ + σ_j¹²))
# → Σ(k≠l) (u(l,k) + u(l,l)) σ_l²¹ + ...
```

The fix is one line: use `_substitute_ne` so `k ≠ l` becomes `ext ≠ l` on the diagonal, which is exactly what `Σ` already does (its comment even spells out why dropping it double-counts). `_drop_ne_with` had no other callers, so it goes too.

After:

```
commutator(σ_l²², Σ_{j,k} u(j,k)(σ_j²¹ + σ_j¹²))
# → u(l,l) σ_l²¹ - u(l,l) σ_l¹² + Σ(k≠l) (u(l,k) σ_l²¹ - u(l,k) σ_l¹²)
```

Regression test added in `canonical_models_test.jl`: the commutator above against the hand-derived result, plus a check that nothing `k`-dependent survives without the `k ≠ l` constraint.

This is only half of #198. QuantumCumulants had a matching over-count in its averaging (re-splitting a sum that was already split); that half is in a companion QC PR, and I'll bump the QC compat to `0.9.3` once this is tagged.
