### PR TITLE
Throw a clear error for String names (operators, Hilbert spaces, indices)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -282,4 +282,5 @@ These names keep their meaning across the migration. Code that only uses them sh
 [v0.9.1]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/releases/tag/v0.9.1
 [v0.9.2]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/releases/tag/v0.9.2
 [v0.9.3]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/releases/tag/v0.9.3
+[v0.9.4]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/releases/tag/v0.9.4
 [#156]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/issues/156

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,12 @@ All notable changes to [`SecondQuantizedAlgebra.jl`](https://github.com/qojulia/
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.9.4]
+
+### Changed
+
+- Passing a `String` where a name `Symbol` is expected now throws a clear `ArgumentError` telling the user to use a `Symbol` (`:x`), instead of a cryptic `MethodError`. This covers Hilbert-space constructors (`FockSpace`, `NLevelSpace`, `PauliSpace`, `SpinSpace`, `PhaseSpace`), operator constructors (`Destroy`, `Create`, `Transition`, `Pauli`, `Spin`, `Position`, `Momentum`), and the index-related constructors `Index`, `IndexedVariable`, and `DoubleIndexedVariable`. Names remain `Symbol`s by design: a single canonical name type keeps name comparison and interning type-stable, so strings are rejected rather than silently converted.
+
 ## [v0.9.3]
 
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SecondQuantizedAlgebra"
 uuid = "f7aa4685-e143-4cb6-a7f3-073579757907"
-version = "0.9.3"
+version = "0.9.4"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/expressions/index.jl
+++ b/src/expressions/index.jl
@@ -26,6 +26,7 @@ function IndexedVariable(name::Symbol, i::Index)
     )
     return Num(f(SymbolicUtils.unwrap(index_sym(i))))
 end
+IndexedVariable(name::AbstractString, args...) = _name_must_be_symbol(name)
 
 """Metadata key: marks a `DoubleIndexedVariable` node where equal indices must give zero."""
 struct NotIdentical end
@@ -74,6 +75,7 @@ function DoubleIndexedVariable(
     end
     return Num(node)
 end
+DoubleIndexedVariable(name::AbstractString, args...; kwargs...) = _name_must_be_symbol(name)
 
 """
     change_index(expr, from::Index, to::Index)

--- a/src/expressions/index_types.jl
+++ b/src/expressions/index_types.jl
@@ -83,6 +83,7 @@ end
 function Index(h::HilbertSpace, name::Symbol, range::Union{Int, Num}, si::Int)
     return Index(_intern_name(name), _intern_range(range), Int32(si), Int32(0))
 end
+Index(h::HilbertSpace, name::AbstractString, args...) = _name_must_be_symbol(name)
 
 """
     (i::Index)(k::Integer) -> Index

--- a/src/operators/fock.jl
+++ b/src/operators/fock.jl
@@ -52,6 +52,9 @@ end
 Destroy(h::ProductSpace, name::Symbol) = Destroy(h, name, _unique_subspace_index(h, FockSpace))
 Create(h::ProductSpace, name::Symbol) = Create(h, name, _unique_subspace_index(h, FockSpace))
 
+Destroy(::HilbertSpace, name::AbstractString, args...) = _name_must_be_symbol(name)
+Create(::HilbertSpace, name::AbstractString, args...) = _name_must_be_symbol(name)
+
 """
     IndexedOperator(op::Op, i::Index) -> Op
 

--- a/src/operators/hilbertspace.jl
+++ b/src/operators/hilbertspace.jl
@@ -8,6 +8,12 @@ tensor products. Compose with [`⊗`](@ref) or [`tensor`](@ref).
 """
 abstract type HilbertSpace end
 
+# Hilbert-space and operator names are `Symbol`s by design (a single canonical
+# name type keeps comparisons and interning type-stable). Passing a `String`
+# would otherwise surface a cryptic `MethodError`; guide the user to `:name`.
+@noinline _name_must_be_symbol(name::AbstractString) =
+    throw(ArgumentError("name must be a `Symbol`, not a `String`; use `:$name` instead of `\"$name\"`"))
+
 """
     FockSpace(name::Symbol) <: HilbertSpace
 
@@ -26,6 +32,7 @@ See also [`Destroy`](@ref), [`Create`](@ref), [`⊗`](@ref).
 struct FockSpace <: HilbertSpace
     name::Symbol
 end
+FockSpace(name::AbstractString) = _name_must_be_symbol(name)
 Base.:(==)(a::FockSpace, b::FockSpace) = a.name == b.name
 Base.hash(a::FockSpace, h::UInt) = hash(:FockSpace, hash(a.name, h))
 

--- a/src/operators/nlevel.jl
+++ b/src/operators/nlevel.jl
@@ -42,6 +42,7 @@ NLevelSpace(name::Symbol, n::Int) = NLevelSpace(name, n, 1, _EMPTY_LEVELS)
 function NLevelSpace(name::Symbol, levels::Tuple{Vararg{Symbol}})
     return NLevelSpace(name, length(levels), 1, collect(Symbol, levels))
 end
+NLevelSpace(name::AbstractString, args...) = _name_must_be_symbol(name)
 
 """
     _level_index(h::NLevelSpace, s::Symbol) -> Int
@@ -120,3 +121,5 @@ Transition(h::ProductSpace, name::Symbol, i::Int, j::Int) =
     Transition(h, name, i, j, _unique_subspace_index(h, NLevelSpace))
 Transition(h::ProductSpace, name::Symbol, i::Symbol, j::Symbol) =
     Transition(h, name, i, j, _unique_subspace_index(h, NLevelSpace))
+
+Transition(::HilbertSpace, name::AbstractString, args...) = _name_must_be_symbol(name)

--- a/src/operators/pauli.jl
+++ b/src/operators/pauli.jl
@@ -16,6 +16,7 @@ See also [`Pauli`](@ref), [`SpinSpace`](@ref).
 struct PauliSpace <: HilbertSpace
     name::Symbol
 end
+PauliSpace(name::AbstractString) = _name_must_be_symbol(name)
 Base.:(==)(a::PauliSpace, b::PauliSpace) = a.name == b.name
 Base.hash(a::PauliSpace, h::UInt) = hash(:PauliSpace, hash(a.name, h))
 
@@ -60,6 +61,8 @@ end
 # Auto-detect subspace when the ProductSpace contains exactly one PauliSpace.
 Pauli(h::ProductSpace, name::Symbol, axis::Int) =
     Pauli(h, name, axis, _unique_subspace_index(h, PauliSpace))
+
+Pauli(::HilbertSpace, name::AbstractString, args...) = _name_must_be_symbol(name)
 
 # Per-site Levi-Civita lookup (3×3 antisymmetric); shared by Pauli and Spin
 # hooks in `operators.jl`. _levi_civita[j][k] = ε_{jk(6-j-k)}.

--- a/src/operators/phase_space.jl
+++ b/src/operators/phase_space.jl
@@ -17,6 +17,7 @@ See also [`Position`](@ref), [`Momentum`](@ref), [`FockSpace`](@ref).
 struct PhaseSpace <: HilbertSpace
     name::Symbol
 end
+PhaseSpace(name::AbstractString) = _name_must_be_symbol(name)
 Base.:(==)(a::PhaseSpace, b::PhaseSpace) = a.name == b.name
 Base.hash(a::PhaseSpace, h::UInt) = hash(:PhaseSpace, hash(a.name, h))
 
@@ -74,3 +75,6 @@ end
 # Auto-detect subspace when the ProductSpace contains exactly one PhaseSpace.
 Position(h::ProductSpace, name::Symbol) = Position(h, name, _unique_subspace_index(h, PhaseSpace))
 Momentum(h::ProductSpace, name::Symbol) = Momentum(h, name, _unique_subspace_index(h, PhaseSpace))
+
+Position(::HilbertSpace, name::AbstractString, args...) = _name_must_be_symbol(name)
+Momentum(::HilbertSpace, name::AbstractString, args...) = _name_must_be_symbol(name)

--- a/src/operators/spin.jl
+++ b/src/operators/spin.jl
@@ -18,6 +18,7 @@ See also [`Spin`](@ref), [`PauliSpace`](@ref).
 struct SpinSpace <: HilbertSpace
     name::Symbol
 end
+SpinSpace(name::AbstractString) = _name_must_be_symbol(name)
 Base.:(==)(a::SpinSpace, b::SpinSpace) = a.name == b.name
 Base.hash(a::SpinSpace, h::UInt) = hash(:SpinSpace, hash(a.name, h))
 
@@ -59,3 +60,5 @@ end
 # Auto-detect subspace when the ProductSpace contains exactly one SpinSpace.
 Spin(h::ProductSpace, name::Symbol, axis::Int) =
     Spin(h, name, axis, _unique_subspace_index(h, SpinSpace))
+
+Spin(::HilbertSpace, name::AbstractString, args...) = _name_must_be_symbol(name)

--- a/test/operators/string_names_test.jl
+++ b/test/operators/string_names_test.jl
@@ -1,0 +1,58 @@
+using SecondQuantizedAlgebra
+using Test
+
+@testset "string names rejected" begin
+    @testset "Hilbert spaces" begin
+        @test_throws ArgumentError FockSpace("c")
+        @test_throws ArgumentError PauliSpace("s")
+        @test_throws ArgumentError SpinSpace("S")
+        @test_throws ArgumentError PhaseSpace("o")
+        @test_throws ArgumentError NLevelSpace("atom", 3)
+        @test_throws ArgumentError NLevelSpace("atom", 3, 2)
+        @test_throws ArgumentError NLevelSpace("atom", (:g, :e))
+    end
+
+    @testset "Operators — single space" begin
+        h = FockSpace(:c)
+        @test_throws ArgumentError Destroy(h, "a")
+        @test_throws ArgumentError Create(h, "a")
+
+        hn = NLevelSpace(:atom, 3)
+        @test_throws ArgumentError Transition(hn, "s", 1, 2)
+
+        @test_throws ArgumentError Pauli(PauliSpace(:s), "σ", 1)
+        @test_throws ArgumentError Spin(SpinSpace(:S), "S", 1)
+
+        hx = PhaseSpace(:o)
+        @test_throws ArgumentError Position(hx, "x")
+        @test_throws ArgumentError Momentum(hx, "p")
+    end
+
+    @testset "Operators — product space" begin
+        hp = FockSpace(:a) ⊗ FockSpace(:b)
+        @test_throws ArgumentError Destroy(hp, "a", 1)
+        @test_throws ArgumentError Create(hp, "b", 2)
+    end
+
+    @testset "Indices and indexed variables" begin
+        h = FockSpace(:c)
+        @test_throws ArgumentError Index(h, "i", 3, h)
+        @test_throws ArgumentError Index(h, "i", 3, 1)
+        i = Index(h, :i, 3, h)
+        j = Index(h, :j, 3, h)
+        @test_throws ArgumentError IndexedVariable("g", i)
+        @test_throws ArgumentError DoubleIndexedVariable("J", i, j)
+        @test_throws ArgumentError DoubleIndexedVariable("J", i, j; identical = false)
+    end
+
+    @testset "Message guides to Symbol" begin
+        err = try
+            FockSpace("cavity")
+        catch e
+            e
+        end
+        @test err isa ArgumentError
+        @test occursin("Symbol", err.msg)
+        @test occursin(":cavity", err.msg)
+    end
+end


### PR DESCRIPTION
resolves #203 

- The convenience is tiny. :x vs "x" is a one-character difference, and :x is the idiomatic Julia spelling for a name. This isn't solving a real pain point, it's shaving a keystroke.

- It cuts against the package's grain. The whole design ethos here (restrictive signatures, single concrete types, one canonical form) is about deliberate constraints. A single canonical name type fits that