### PR TITLE
fix: render index slot suffixes as a comma subscript

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,12 @@ All notable changes to [`SecondQuantizedAlgebra.jl`](https://github.com/qojulia/
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.9.5]
+
+### Fixed
+
+- LaTeX rendering of an index whose name carries numeric per-slot suffixes no longer produces an invalid double subscript. As the pipeline transforms an index it accumulates suffixes through `(i::Index)(k)` (for example an index reaches `i_2_1` when a second distinct atom `i(2)` is later collapsed to its position-1 representative), and `_latex_index_suffix` emitted the name verbatim as `_{i_2_1}`. The unbraced `_2_1` is a double subscript that MathJax rejects with "Double subscripts: use braces to clarify", so the whole equation was left unrendered in Documenter pages and notebooks. The slot numbers are now joined into a single comma subscript (`i_2_1` renders as `i_{2,1}`); bare index names are unchanged.
+
 ## [v0.9.4]
 
 ### Changed
@@ -283,4 +289,5 @@ These names keep their meaning across the migration. Code that only uses them sh
 [v0.9.2]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/releases/tag/v0.9.2
 [v0.9.3]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/releases/tag/v0.9.3
 [v0.9.4]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/releases/tag/v0.9.4
+[v0.9.5]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/releases/tag/v0.9.5
 [#156]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/issues/156

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SecondQuantizedAlgebra"
 uuid = "f7aa4685-e143-4cb6-a7f3-073579757907"
-version = "0.9.4"
+version = "0.9.5"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/printing/latexify_recipes.jl
+++ b/src/printing/latexify_recipes.jl
@@ -23,9 +23,13 @@ function transition_superscript(x::Bool)
     return x
 end
 
+# Join accumulated per-slot suffixes into one comma subscript (`i_2_1` -> `i_{2,1}`);
+# a bare `_{i_2_1}` is a double subscript that MathJax rejects.
 function _latex_index_suffix(idx::Index)
     has_index(idx) || return ""
-    return "_{$(index_name(idx))}"
+    parts = split(string(index_name(idx)), '_')
+    name = length(parts) == 1 ? parts[1] : string(parts[1], "_{", join(parts[2:end], ","), "}")
+    return "_{$(name)}"
 end
 
 # Render an operator name for LaTeX. A bare name (`:a`) passes through, but a

--- a/test/printing/printing_test.jl
+++ b/test/printing/printing_test.jl
@@ -351,6 +351,23 @@ import SecondQuantizedAlgebra: simplify, QAdd, QSym, _single_qadd, _zero_qadd, _
             end
         end
 
+        @testset "Index slot suffixes render as comma subscript" begin
+            # `i_2_1` (accumulated slot suffixes) must render as `i_{2,1}`, not the
+            # invalid double subscript `_{i_2_1}`; bare names are unchanged.
+            @variables N
+            h2 = FockSpace(:c) ⊗ NLevelSpace(:atom, 2, 1)
+            i = Index(h2, :i, N, NLevelSpace(:atom, 2, 1))
+            iu = Index(h2, Symbol("i_2_1"), N, NLevelSpace(:atom, 2, 1))
+
+            cases = [
+                (IndexedOperator(Transition(h2, :σ, 1, 2, 2), i), L"{\sigma}_{i}^{{12}}"),
+                (IndexedOperator(Transition(h2, :σ, 1, 2, 2), iu), L"{\sigma}_{i_{2,1}}^{{12}}"),
+            ]
+            for (input, out) in cases
+                @test latexify(input) == out
+            end
+        end
+
         @testset "Transition superscript toggle" begin
             hn = NLevelSpace(:atom, 3, 1)
             σ12 = Transition(hn, :σ, 1, 2)


### PR DESCRIPTION
## Problem

An index accumulates numeric per-slot suffixes as the pipeline transforms it, via `(i::Index)(k)` (which does `Symbol(name, "_", k)`). For example an index reaches `i_2_1` when completion mints a second distinct atom `i(2)` (`i_2`, slot 2) and `scale` later collapses it to its position-1 representative `(i_2)(1)` (`i_2_1`, slot 1).

`_latex_index_suffix` emitted the name verbatim as `_{i_2_1}`. The unbraced `_2_1` is a double subscript, which MathJax rejects with *"Double subscripts: use braces to clarify"*, so the entire equation was left unrendered (raw LaTeX source) in Documenter pages and notebooks.

Surfaced by the QuantumCumulants `superradiant_laser_indexed` example (`corr_sc.eqs`), while investigating QuantumCumulants PR [#317](https://github.com/qojulia/QuantumCumulants.jl/pull/317).

## Fix

The suffixes are slot numbers, so join them into a single comma subscript: `i_2_1` renders as `i_{2,1}`. Bare index names (`:i`, `:j`) have no suffix and are unchanged.

The accumulated `_2` part is load-bearing (it distinguishes the second-atom representative from the first, so two-atom moments do not fold into same-atom ones), so the name itself is preserved; only its rendering changes.

## Tests

Added a regression testset in `test/printing/printing_test.jl` pinning `i_{2,1}` and confirming bare names are untouched. All 133 rendering tests pass.

Verified the transformed output renders in both MathJax v2 and v3.