### PR TITLE
perf: reduce TTFX (type-stability fixes + tuned precompile workload)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,14 @@ Before merging any PR:
 - **No `using X` without explicit imports.** Use `using X: func1, func2` or `import X`. ExplicitImports.jl enforces this.
 - **Format with Runic.** Run `make format` before committing.
 
+## Performance terminology
+
+Three distinct axes; keep them separate when reporting numbers.
+
+- **Precompilation time**: compiling package code into the on-disk cache. Paid once per version/dependency change, not per session; where `precompile.jl`'s `@compile_workload` runs.
+- **TTFX**: cold-process latency to the *first* call: `using` load time plus any JIT not cached during precompilation. A bigger `@compile_workload` trades more precompilation time for less TTFX.
+- **Runtime**: steady-state cost of every call after the first, no compilation. What `@btime`/`benchmark/` measure after warmup; target of the zero-allocation passes.
+
 ## Dependencies
 
 | Package | Purpose |

--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,8 @@ Numeric conversion (`to_numeric`/`numeric_average`/`expect`) was redesigned to b
 - A uniform Hilbert-space entry point `to_numeric(op, h::HilbertSpace, dims; backend, parameter, time_parameter, operators, adjoint_ops, op_type)`. It builds the backend basis from `dims` (Fock cutoff / spin number) and is the only form that works for both backends. The backend defaults to the single loaded one.
 - Open backend hooks `numeric_operator`, `numeric_basis`, `numeric_subbasis`, `numeric_embed`, `numeric_identity`, `numeric_num_subsystems`, `numeric_assemble`, `numeric_assemble_td`, `numeric_materialize`, `numeric_expect`, and `numeric_backend` are exported. Downstream packages can implement another backend and add numeric support for existing operator roles; `OpKind` remains a closed symbolic-role set.
 
+- Some TTFX motivated changes and more complicated precompile workload. [#223](https://github.com/qojulia/SecondQuantizedAlgebra.jl/issues/223)
+
 ### Changed (breaking)
 
 - `QuantumOpticsBase` moved from a hard dependency to a weak dependency. Using the numeric API now requires loading a backend: add `using QuantumOpticsBase` (or `using QuantumToolbox`) next to `using SecondQuantizedAlgebra`. The lightweight `QuantumInterface.jl` is a new hard dependency (it owns the `⊗`/`tensor`/`expect`/`basis` generics that the algebra extends).
@@ -30,11 +32,6 @@ Numeric conversion (`to_numeric`/`numeric_average`/`expect`) was redesigned to b
 ### Fixed
 
 - An elementary function of a literal zero left unevaluated by Symbolics (e.g. the `exp(0)` factor produced when `exp(im*ω*t)` is Euler-expanded to `cos(ω t)*exp(0) + exp(0)*im*sin(ω t)`) is now folded to its exact value in the coefficient algebra, so it no longer leaks into printed equations. Only exact identities at argument `0` fold (`exp/cos/cosh → 1`, `sin/tan/sinh/tanh → 0`); non-zero or non-constant arguments (`exp(2)`, `sin(π)`) stay symbolic.
-
-### Notes
-
-- For static conversion, the `op_type` contract from v0.9.2 is now backend-neutral: `to_numeric` assembles the operator lazily and materializes it once via `op_type`, so the return type depends only on `op_type`, not on the expression shape. The default consistently returns an eager backend operator (sparse on both bundled backends). Pass an explicit `op_type` for another eager representation (`dense` on QuantumOptics; `QuantumToolbox.to_sparse`/`to_dense` or `SciMLOperators.concretize` on QuantumToolbox), or `op_type=identity` for the natural lazy representation (`LazyTensor`/`LazyProduct`/`LazySum` / `QobjEvo` over `VecSum`). The lazy form is the internal assembly primitive and is what `numeric_average`/`expect` consume directly, so `LazyKet` states work without materializing.
-- A user doing `using SecondQuantizedAlgebra, QuantumToolbox` has two `⊗`/`tensor`/`expect` in scope (QuantumInterface's and QuantumToolbox's) and must qualify them; importing QuantumToolbox as `import QuantumToolbox as QTB` avoids the clash.
 
 
 ## [v0.9.4]

--- a/src/expressions/cnum.jl
+++ b/src/expressions/cnum.jl
@@ -79,15 +79,24 @@ _to_cnum(x::SymbolicUtils.BasicSymbolic) = _recognize(x)
 _cnum(re::Num, im::Num) =
     _add_cnum(_recognize(SymbolicUtils.unwrap(re)), _mul_cnum(_CNUM_IM, _recognize(SymbolicUtils.unwrap(im))))
 
+# Function barrier: `_numeric_value` yields an abstract `Number`, so folding here
+# (rather than inline in `_cnum_sym`) specializes the round-trip on the concrete
+# type and replaces four boxed `Number` dispatches with one. Returns `nothing` when
+# the value does not round-trip through `ComplexF64` losslessly.
+@noinline function _native_fold(rv::Number, iv::Number)
+    w = rv + Complex(false, true) * iv
+    z = ComplexF64(w)
+    return z == w ? z : nothing
+end
+
 # Rebuild after a materialized symbolic arithmetic step: folds a numeric constant
 # back to native, else stays symbolic. Must NOT re-enter `_recognize` (would recurse).
 function _cnum_sym(re::Num, im::Num)
     rv = _numeric_value(re)
     iv = _numeric_value(im)
     if rv isa Number && iv isa Number
-        w = rv + Complex(false, true) * iv
-        z = ComplexF64(w)
-        z == w && return _native(z)
+        z = _native_fold(rv, iv)
+        z !== nothing && return _native(z)
     end
     return _symbolic(Complex(re, im))
 end
@@ -293,20 +302,36 @@ function _recognize_sum(args)::Coeff
     return have_sym ? _add_cnum(poly, sym) : poly
 end
 
+# Insertion-sort a factor list (syms + matching exps) in place by objectid key.
+# Avoids Base's `sortperm` machinery for the abstract `BasicSymbolic` eltype, whose
+# inference is a nontrivial slice of first-call latency; these lists are tiny.
+function _sort_factors!(syms::Vector{SymbolicUtils.BasicSymbolic}, exps::Vector{Rational{Int}})
+    @inbounds for i in 2:length(syms)
+        s = syms[i]; e = exps[i]; k = _fkey(s)
+        j = i - 1
+        while j >= 1 && _fkey(syms[j]) > k
+            syms[j + 1] = syms[j]; exps[j + 1] = exps[j]
+            j -= 1
+        end
+        syms[j + 1] = s; exps[j + 1] = e
+    end
+    return nothing
+end
+
 function _merge_factor_list(syms::Vector{SymbolicUtils.BasicSymbolic}, exps::Vector{Rational{Int}})
     n = length(syms)
     n <= 1 && return (syms, exps)
-    p = sortperm(syms; by = _fkey)
+    _sort_factors!(syms, exps)
     osyms = SymbolicUtils.BasicSymbolic[]
     oexps = Rational{Int}[]
     sizehint!(osyms, n); sizehint!(oexps, n)
     i = 1
     @inbounds while i <= n
-        s = syms[p[i]]
-        e = exps[p[i]]
+        s = syms[i]
+        e = exps[i]
         j = i + 1
-        while j <= n && syms[p[j]] === s
-            e += exps[p[j]]
+        while j <= n && syms[j] === s
+            e += exps[j]
             j += 1
         end
         e != 0 && (push!(osyms, s); push!(oexps, e))
@@ -455,8 +480,9 @@ function _conj_poly(p::Poly)
         for i in 1:n
             nsyms[i] = _conj_atom(m.syms[i])
         end
-        perm = sortperm(nsyms; by = _fkey)
-        terms[k] = Monomial(conj(m.scalar), nsyms[perm], m.exps[perm])
+        nexps = copy(m.exps)
+        _sort_factors!(nsyms, nexps)
+        terms[k] = Monomial(conj(m.scalar), nsyms, nexps)
     end
     return _from_poly(_canonical_terms!(terms))
 end

--- a/src/expressions/cnum.jl
+++ b/src/expressions/cnum.jl
@@ -79,24 +79,15 @@ _to_cnum(x::SymbolicUtils.BasicSymbolic) = _recognize(x)
 _cnum(re::Num, im::Num) =
     _add_cnum(_recognize(SymbolicUtils.unwrap(re)), _mul_cnum(_CNUM_IM, _recognize(SymbolicUtils.unwrap(im))))
 
-# Function barrier: `_numeric_value` yields an abstract `Number`, so folding here
-# (rather than inline in `_cnum_sym`) specializes the round-trip on the concrete
-# type and replaces four boxed `Number` dispatches with one. Returns `nothing` when
-# the value does not round-trip through `ComplexF64` losslessly.
-@noinline function _native_fold(rv::Number, iv::Number)
-    w = rv + Complex(false, true) * iv
-    z = ComplexF64(w)
-    return z == w ? z : nothing
-end
-
 # Rebuild after a materialized symbolic arithmetic step: folds a numeric constant
 # back to native, else stays symbolic. Must NOT re-enter `_recognize` (would recurse).
 function _cnum_sym(re::Num, im::Num)
     rv = _numeric_value(re)
     iv = _numeric_value(im)
     if rv isa Number && iv isa Number
-        z = _native_fold(rv, iv)
-        z !== nothing && return _native(z)
+        w = rv + Complex(false, true) * iv
+        z = ComplexF64(w)
+        z == w && return _native(z)
     end
     return _symbolic(Complex(re, im))
 end

--- a/src/expressions/monomial.jl
+++ b/src/expressions/monomial.jl
@@ -76,10 +76,26 @@ function _term_mul(a::Monomial, b::Monomial)
     return Monomial(a.scalar * b.scalar, se[1], se[2])
 end
 
+# Insertion sort by a strict-less predicate. The polynomial passes sort very short
+# vectors; this keeps the whole `Base.Sort` machinery (ScratchQuickSort, partition!,
+# issorted, ...) out of inference, which is a large chunk of first-call latency.
+function _insertion_sort!(v::AbstractVector, lt::F) where {F}
+    @inbounds for i in 2:length(v)
+        x = v[i]
+        j = i - 1
+        while j >= 1 && lt(x, v[j])
+            v[j + 1] = v[j]
+            j -= 1
+        end
+        v[j + 1] = x
+    end
+    return v
+end
+
 # Sort terms into canonical order, merge like-factor terms, drop zero scalars.
 function _canonical_terms!(terms::Vector{Monomial})
     isempty(terms) && return terms
-    sort!(terms; lt = _term_less)
+    _insertion_sort!(terms, _term_less)
     w = 0
     @inbounds for r in eachindex(terms)
         t = terms[r]

--- a/src/expressions/qadd.jl
+++ b/src/expressions/qadd.jl
@@ -38,7 +38,7 @@ function _prune_dead_ne(args::QTermDict, indices::Vector{Index})
         for p in term.ne
             _pair_referenced(p, term.ops, c, indices) && _push_ne_unique!(kept, p)
         end
-        kept_ne = isempty(kept) ? _EMPTY_NE : sort!(kept)
+        kept_ne = isempty(kept) ? _EMPTY_NE : _insertion_sort!(kept, isless)
         _addto_key!(out, QTerm(copy(term.ops), kept_ne), c)
     end
     return out
@@ -150,6 +150,29 @@ Base.eltype(::Type{QAdd}) = Pair{QTerm, CNum}
 
 _ne_sort_key(ne::Vector{NonEqualPair}) = Tuple(ne)
 
+# Type-stable display order. Compares operator sequences field-by-field (each
+# `_full_op_key` is a fixed-length concrete tuple), then the constraint set. This
+# replaces `isless` on the variable-length `Vararg` tuples the `_*_sort_key`
+# helpers build, which inference cannot resolve concretely (a print-path cost).
+function _ne_less(a::Vector{NonEqualPair}, b::Vector{NonEqualPair})
+    la, lb = length(a), length(b)
+    @inbounds for i in 1:min(la, lb)
+        a[i] != b[i] && return isless(a[i], b[i])
+    end
+    return la < lb
+end
+
+function _sorted_args_less(x::Pair{QTerm, CNum}, y::Pair{QTerm, CNum})
+    xo, yo = x.first.ops, y.first.ops
+    lx, ly = length(xo), length(yo)
+    lx != ly && return lx < ly
+    @inbounds for i in 1:lx
+        kx, ky = _full_op_key(xo[i]), _full_op_key(yo[i])
+        kx != ky && return isless(kx, ky)
+    end
+    return _ne_less(x.first.ne, y.first.ne)
+end
+
 """
     sorted_arguments(q::QAdd) -> Vector{QAdd}
 
@@ -169,14 +192,11 @@ julia> length(SecondQuantizedAlgebra.sorted_arguments(a + a'))
 """
 function sorted_arguments(q::QAdd)
     isempty(q.arguments) && return QAdd[]
-    pairs = sort!(
-        collect(q.arguments);
-        by = p -> (_term_sort_key(p.first.ops), _ne_sort_key(p.first.ne)),
-    )
+    pairs = collect(q.arguments)
+    _insertion_sort!(pairs, _sorted_args_less)
     return QAdd[_single_qadd(c, term.ops, term.ne) for (term, c) in pairs]
 end
 
-_term_sort_key(ops::Vector{Op}) = (length(ops), map(_full_op_key, ops)...)
 _full_op_key(op::QSym) = (_sort_key(op)..., _type_order(op), _name_rank(op.name_id))
 
 """
@@ -196,7 +216,7 @@ coefficient contributes its printed form (a reproducible tiebreak, not a numeric
 """
 function qadd_order_key(q::QAdd)
     pairs = [(term_order_key(t), _coeff_key(c)) for (t, c) in q.arguments]
-    sort!(pairs)
+    _insertion_sort!(pairs, isless)
     return pairs
 end
 

--- a/src/expressions/qterm.jl
+++ b/src/expressions/qterm.jl
@@ -60,7 +60,7 @@ function _canonical_ne(ne::Vector{NonEqualPair})
     for p in ne
         _push_ne_unique!(out, p)
     end
-    sort!(out)
+    _insertion_sort!(out, isless)
     return isempty(out) ? _EMPTY_NE : out
 end
 

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -37,19 +37,19 @@ precompile(to_num, (CNum,))
     @compile_workload begin
         let io = IOBuffer()
             h = FockSpace(:a); a = Destroy(h, :a); ad = Create(h, :a)
-            show(io, a*ad); show(io, a + ad); show(io, a'); show(io, a - 2*ad)
-            show(io, commutator(a, ad)); show(io, (a + ad)*(a - ad))
+            show(io, a * ad); show(io, a + ad); show(io, a'); show(io, a - 2 * ad)
+            show(io, commutator(a, ad)); show(io, (a + ad) * (a - ad))
             hn = NLevelSpace(:atom, 3); s12 = Transition(hn, :σ, 1, 2); s21 = Transition(hn, :σ, 2, 1)
-            show(io, s12*s21); show(io, normal_order(s21*s12))
+            show(io, s12 * s21); show(io, normal_order(s21 * s12))
             show(io, expand_completeness(Transition(hn, :σ, 2, 2)))
             hs = SpinSpace(:s); show(io, commutator(Spin(hs, :S, 1), Spin(hs, :S, 2)))
-            hp = PauliSpace(:p); show(io, Pauli(hp, :σ, 1)*Pauli(hp, :σ, 2))
+            hp = PauliSpace(:p); show(io, Pauli(hp, :σ, 1) * Pauli(hp, :σ, 2))
             @variables g Δ
-            H = g*ad*a + Δ*(a + ad); show(io, H); show(io, H')
-            show(io, average(H)); show(io, undo_average(average(a*ad)))
+            H = g * ad * a + Δ * (a + ad); show(io, H); show(io, H')
+            show(io, average(H)); show(io, undo_average(average(a * ad)))
             show(io, simplify(H)); substitute(H, Dict(g => 1.0))
             let i = Index(h, :i, 3, h)
-                show(io, Σ(IndexedOperator(ad, i)*IndexedOperator(a, i), i))
+                show(io, Σ(IndexedOperator(ad, i) * IndexedOperator(a, i), i))
             end
         end
     end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,6 +1,7 @@
 using PrecompileTools: @setup_workload, @compile_workload
 
-# Targeted precompile directives for internal methods.
+# === Explicit directives ===
+# Internal entry points the workload does not fully exercise (indexed `_merge_*`).
 precompile(_canonicalize!, (QTermDict, Vector{Op}, CNum, Vector{NonEqualPair}))
 precompile(_addto!, (QTermDict, Vector{Op}, CNum, Vector{NonEqualPair}))
 precompile(_iszero_cnum, (CNum,))
@@ -8,15 +9,48 @@ precompile(_neg_cnum, (CNum,))
 precompile(_merge_unique, (Vector{Index}, Vector{Index}))
 precompile(_merge_ne, (Vector{NonEqualPair}, Vector{NonEqualPair}))
 
-# Minimal workload: a single commutator covers Sort, Dict, Symbolics Num paths,
-# ordering, QAdd subtraction, and _merge_unique.
+# Scalar prefactor products across the numeric types users write literally, in both
+# argument orders (a type loop; the workload only exercises `Int`/`Num` coefficients).
+for T in (Int, Float64, ComplexF64, Rational{Int}, Num)
+    precompile(*, (T, Op))
+    precompile(*, (Op, T))
+end
+# Public single-term accessors, not reached by the display-driven workload.
+precompile(prefactor, (QAdd,))
+precompile(operators, (QAdd,))
+precompile(to_num, (CNum,))
+
+# === Representative workload ===
+# Covers the common user surface: each operator kind, the full arithmetic/
+# canonicalization pipeline (including QAdd*QAdd), normal_order, symbolic (parameter)
+# coefficients, average/undo_average, simplify, substitute, expand_completeness, an
+# indexed sum, and display of every result (the universal REPL path). Wrapped in
+# `let` (Makie-style) so no workload local is serialized into the pkgimage.
+#
+# Balance (measured, Julia 1.12 / SymbolicUtils 4.40): precompilation ~6.1s -> ~11s
+# (paid once per install), cutting first-call latency of a full build/manipulate/
+# average/simplify/show workflow from ~3.5s to ~0.2s (paid every session). `average`
+# and `simplify` share the SymbolicUtils machinery (together ~+3s), and the indexed
+# and substitute lines ~+1s; drop those lines to trim precompilation if leaner is
+# wanted.
 @setup_workload begin
     @compile_workload begin
-        h = FockSpace(:a)
-        a = Destroy(h, :a)
-        ad = Create(h, :a)
-        commutator(a, ad)
+        let io = IOBuffer()
+            h = FockSpace(:a); a = Destroy(h, :a); ad = Create(h, :a)
+            show(io, a*ad); show(io, a + ad); show(io, a'); show(io, a - 2*ad)
+            show(io, commutator(a, ad)); show(io, (a + ad)*(a - ad))
+            hn = NLevelSpace(:atom, 3); s12 = Transition(hn, :σ, 1, 2); s21 = Transition(hn, :σ, 2, 1)
+            show(io, s12*s21); show(io, normal_order(s21*s12))
+            show(io, expand_completeness(Transition(hn, :σ, 2, 2)))
+            hs = SpinSpace(:s); show(io, commutator(Spin(hs, :S, 1), Spin(hs, :S, 2)))
+            hp = PauliSpace(:p); show(io, Pauli(hp, :σ, 1)*Pauli(hp, :σ, 2))
+            @variables g Δ
+            H = g*ad*a + Δ*(a + ad); show(io, H); show(io, H')
+            show(io, average(H)); show(io, undo_average(average(a*ad)))
+            show(io, simplify(H)); substitute(H, Dict(g => 1.0))
+            let i = Index(h, :i, 3, h)
+                show(io, Σ(IndexedOperator(ad, i)*IndexedOperator(a, i), i))
+            end
+        end
     end
 end
-# precompile load from 6s to 11s, but TTFX for mul, commutator below 1s.
-# do not add simplify as this adds an additional 7s of precompilation time due to SU.jl TTFX.

--- a/src/printing/printing.jl
+++ b/src/printing/printing.jl
@@ -90,21 +90,31 @@ end
 _is_neg_unit(c::Number) = isequal(c, -1)
 
 function _is_real_negative(c::CNum)
-    if _iszero_num(imag(c))
-        r = Symbolics.value(SymbolicUtils.unwrap(real(c)))
-        return r isa Real && r < 0
-    end
-    return false
+    _is_native(c) && return imag(c.z) == 0 && real(c.z) < 0
+    return _is_real_negative_sym(c)
+end
+# Cold path: a non-native coefficient is a real negative only for symbolic constants
+# that don't round-trip to `ComplexF64` (irrationals like `-π`, exact rationals).
+# Isolated so the hot native branch stays concrete. `::Bool` pins the result: `<` on
+# the abstract-typed `r` is unprovably `Bool` to inference (the Symbolics boundary),
+# and leaving it `Any` would poison the `_show_terms` caller.
+@noinline function _is_real_negative_sym(c::CNum)::Bool
+    _iszero_num(imag(c)) || return false
+    r = Symbolics.value(SymbolicUtils.unwrap(real(c)))
+    return r isa Real && r < 0
 end
 _is_real_negative(::Number) = false
 
 # Check if a symbolic prefactor needs parentheses when followed by operators.
+# A native (plain-number) coefficient never needs them; only a symbolic `/` or `+`
+# head does. Unwrapping to a typed `BasicSymbolic` keeps `operation` a static call.
 function _needs_pf_parens(c::CNum)
+    _is_native(c) && return false
     iszero(imag(c)) || return false
-    r = Symbolics.value(SymbolicUtils.unwrap(real(c)))
-    r isa Number && return false
-    SymbolicUtils.iscall(r) || return false
-    op = SymbolicUtils.operation(r)
+    u = SymbolicUtils.unwrap(real(c))
+    u isa SymbolicUtils.BasicSymbolic || return false
+    SymbolicUtils.iscall(u) || return false
+    op = SymbolicUtils.operation(u)
     return op === (/) || op === (+)
 end
 


### PR DESCRIPTION


Reduces time-to-first-execution through source-level type-stability fixes and a representative precompile workload, guided by SnoopCompile and JET.

## Type-stability / inference
* Replace `Base.Sort` over custom types with a small insertion sort in the polynomial, term, and QAdd ordering passes.
* Printing predicates get a native fast path with the symbolic branch isolated in a cold barrier (`_is_real_negative`, `_needs_pf_parens`).
* `sorted_arguments` compares operator sequences via a concrete field-by-field key instead of variable-length `Vararg` tuples.

Removes ~130 first-call `MethodInstance`s on the representative workload; the printing path infers cleanly.

## Precompile workload
Replaces the single-commutator workload with one covering every operator kind, the full arithmetic/canonicalization pipeline, `normal_order`, symbolic coefficients, `average`, `simplify`, `substitute`, `expand_completeness`, an indexed sum, and display. Adds explicit directives (a scalar-type loop over `Number*Op` and the public accessors `prefactor`/`operators`/`to_num`).

Measured on Julia 1.12 / SymbolicUtils 4.40: precompilation goes from ~6s to ~11s (once per install), and a full build/manipulate/average/simplify/show first-workflow drops from ~3.5s to ~0.2s (every session).s.
