### PR TITLE
feat: proper `variables` and `operators` collectors

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+##  [v0.12.0]
+
+### Added
+
+- Added `get_operators` and `get_variables` introspection for `QAdd` expressions, including filtered and buffer forms of the `Symbolics.get_variables` interface.
+
+### Changed
+
+- Renamed expression accessors to `get_prefactor`, `get_operators`, and `get_variables`, and renamed adjoint-aware deduplication to `unique_up_to_adjoint`.
+
+
 ##  [v0.11.1]
 
 ### Added
@@ -371,4 +382,5 @@ These names keep their meaning across the migration. Code that only uses them sh
 [v0.10.1]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/releases/tag/v0.10.1
 [v0.11.0]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/releases/tag/v0.11.0
 [v0.11.1]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/releases/tag/v0.11.1
+[v0.12.0]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/releases/tag/v0.12.0
 [#156]: https://github.com/qojulia/SecondQuantizedAlgebra.jl/issues/156

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SecondQuantizedAlgebra"
 uuid = "f7aa4685-e143-4cb6-a7f3-073579757907"
-version = "0.11.1"
+version = "0.12.0"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -294,11 +294,11 @@ find_operators
 ```
 
 ```@docs
-unique_ops
+unique_up_to_adjoint
 ```
 
 ```@docs
-unique_ops!
+unique_up_to_adjoint!
 ```
 
 ```@docs
@@ -306,7 +306,7 @@ fundamental_operators
 ```
 
 ```@docs
-prefactor
+get_prefactor
 ```
 
 ```@docs
@@ -314,7 +314,11 @@ to_num
 ```
 
 ```@docs
-operators
+get_operators
+```
+
+```@docs
+get_variables
 ```
 
 ```@docs

--- a/src/SecondQuantizedAlgebra.jl
+++ b/src/SecondQuantizedAlgebra.jl
@@ -1,9 +1,10 @@
 module SecondQuantizedAlgebra
 
 using SymbolicUtils: SymbolicUtils, simplify, substitute, add_worker
-using Symbolics: Symbolics, Num, expand, @variables, build_function, symbolic_to_float
+using Symbolics: Symbolics, Num, expand, @variables, build_function, get_variables, symbolic_to_float
 using TermInterface: TermInterface
 
+import QuantumInterface
 import QuantumInterface: expect, basis, dagger
 using QuantumInterface: AbstractOperator, StateVector, Basis
 import TensorCore: ⊗, tensor
@@ -113,8 +114,8 @@ export FockSpace, ProductSpace,
     @qnumbers, @variables,
     average, undo_average, make_time_dependent,
     acts_on, is_average, is_indexed_sum,
-    fundamental_operators, find_operators, unique_ops,
-    prefactor, operators,
+    fundamental_operators, find_operators, unique_up_to_adjoint,
+    get_prefactor, get_operators, get_variables,
     substitute,
     normal_order, normal_to_symmetric, symmetric_to_normal,
     UnitaryTransform, RotatingFrame, Displace, DisplacementFrame, Rotation, Squeeze, Bogoliubov,

--- a/src/expressions/cnum.jl
+++ b/src/expressions/cnum.jl
@@ -1027,7 +1027,7 @@ function Base.hash(c::Coeff, h::UInt)
 end
 
 # Coefficients are routinely compared against plain numbers / `Complex{Num}`
-# (e.g. `prefactor(x) == 2`, `q[key] == CNUM_ONE`); promote the number side.
+# (e.g. `get_prefactor(x) == 2`, `q[key] == CNUM_ONE`); promote the number side.
 Base.isequal(a::Coeff, b::Number) = isequal(a, to_cnum(b))
 Base.isequal(a::Number, b::Coeff) = isequal(to_cnum(a), b)
 Base.:(==)(a::Coeff, b::Number) = isequal(a, to_cnum(b))

--- a/src/expressions/qadd.jl
+++ b/src/expressions/qadd.jl
@@ -7,7 +7,7 @@ All arithmetic on [`QSym`](@ref) operators produces a `QAdd`. Iterating over a
 `QAdd` yields `Pair{QTerm, CNum}` entries; read `term.ops` for the operator
 sequence and `term.ne` for the scoped index constraints.
 
-See also [`QTerm`](@ref), [`prefactor`](@ref), [`operators`](@ref), [`Σ`](@ref),
+See also [`QTerm`](@ref), [`get_prefactor`](@ref), [`get_operators`](@ref), [`Σ`](@ref),
 [`constraint_pairs`](@ref).
 """
 struct QAdd <: QField
@@ -271,7 +271,7 @@ function Base.haskey(q::QAdd, key::AbstractVector{<:QSym})
 end
 
 """
-    prefactor(s::QAdd) -> Complex{Num}
+    get_prefactor(s::QAdd) -> Complex{Num}
 
 Return the `Complex{Num}` prefactor of a single-term [`QAdd`](@ref).
 
@@ -285,27 +285,28 @@ julia> h = FockSpace(:f);
 
 julia> @qnumbers a::Destroy(h);
 
-julia> prefactor(2 * a' * a)
+julia> get_prefactor(2 * a' * a)
 2
 ```
 
-See also [`operators`](@ref), [`sorted_arguments`](@ref).
+See also [`get_operators`](@ref), [`sorted_arguments`](@ref).
 """
-function prefactor(s::QAdd)
+function get_prefactor(s::QAdd)
     length(s.arguments) == 1 || throw(
-        ArgumentError("prefactor requires a single-term expression, got $(length(s.arguments)) terms")
+        ArgumentError("get_prefactor requires a single-term expression, got $(length(s.arguments)) terms")
     )
     return to_num(first(values(s.arguments)))
 end
 
 """
-    operators(s::QAdd) -> Vector{Op}
+    get_operators(s::QAdd) -> Vector{Op}
 
-Return the ordered operator sequence of a single-term [`QAdd`](@ref).
+Return the unique operators occurring in [`QAdd`](@ref) `s`.
 
-Throws `ArgumentError` if `s` contains more than one term. For multi-term
-expressions, iterate over the `QAdd` directly and read `term.ops` from each
-[`QTerm`](@ref).
+The result is sorted by the canonical [`order_key`](@ref). An operator and
+its adjoint are distinct entries; use [`unique_up_to_adjoint`](@ref) when adjoint pairs
+should be treated as one degree of freedom. Repeated factors are returned once;
+read `term.ops` directly when multiplicity must be preserved.
 
 # Examples
 
@@ -314,15 +315,108 @@ julia> h = FockSpace(:f);
 
 julia> @qnumbers a::Destroy(h);
 
-julia> length(operators(a' * a))
+julia> length(get_operators(a' * a))
 2
 ```
 
-See also [`prefactor`](@ref), [`sorted_arguments`](@ref).
+See also [`get_prefactor`](@ref), [`unique_up_to_adjoint`](@ref), [`sorted_arguments`](@ref).
 """
-function operators(s::QAdd)
-    length(s.arguments) == 1 || throw(
-        ArgumentError("operators requires a single-term expression, got $(length(s.arguments)) terms")
+function get_operators(s::QAdd)
+    ops = Op[]
+    for term in keys(s.arguments)
+        append!(ops, term.ops)
+    end
+    unique!(ops)
+    sort!(ops; by = order_key)
+    return ops
+end
+
+"""
+    get_variables(s::QAdd) -> Vector{SymbolicUtils.BasicSymbolic}
+
+Return the unique scalar symbolic variables occurring in the prefactors of
+[`QAdd`](@ref) `s`. Operator leaves are not included. Variables in indexed
+coefficients are returned according to `Symbolics.get_variables`; use
+[`get_indices`](@ref) to inspect the expression's structured index scope.
+
+The returned variables follow the representation used by
+`Symbolics.get_variables`, so they can be passed directly to Symbolics
+functions such as `build_function`. Pass a `varlist` as the second argument
+to restrict the result, or use `Symbolics.get_variables!` to fill a caller-owned
+buffer.
+
+# Examples
+
+```jldoctest
+julia> h = FockSpace(:f);
+
+julia> @qnumbers a::Destroy(h);
+
+julia> @variables ω g;
+
+julia> length(get_variables(ω * a' * a + g * a))
+2
+```
+"""
+function Symbolics.get_variables(s::QAdd; kwargs...)::Vector{SymbolicUtils.BasicSymbolic}
+    vars = SymbolicUtils.BasicSymbolic[]
+    for c in values(s.arguments)
+        append!(vars, Symbolics.get_variables(real(c); kwargs...))
+        append!(vars, Symbolics.get_variables(imag(c); kwargs...))
+    end
+    unique!(vars)
+    sort!(vars; by = string)
+    return vars
+end
+
+function Symbolics.get_variables(
+        s::QAdd,
+        varlist;
+        is_atomic = SymbolicUtils.default_is_atomic,
+        kwargs...,
+    )::Vector{SymbolicUtils.BasicSymbolic}
+    vars = SymbolicUtils.BasicSymbolic[]
+    for c in values(s.arguments)
+        append!(
+            vars,
+            Symbolics.get_variables(
+                real(c), varlist; is_atomic = is_atomic, kwargs...
+            ),
+        )
+        append!(
+            vars,
+            Symbolics.get_variables(
+                imag(c), varlist; is_atomic = is_atomic, kwargs...
+            ),
+        )
+    end
+    unique!(vars)
+    sort!(vars; by = string)
+    return vars
+end
+
+function Symbolics.get_variables!(buffer, s::QAdd; kwargs...)
+    for c in values(s.arguments)
+        Symbolics.get_variables!(buffer, real(c); kwargs...)
+        Symbolics.get_variables!(buffer, imag(c); kwargs...)
+    end
+    return buffer
+end
+
+function Symbolics.get_variables!(
+        buffer,
+        s::QAdd,
+        varlist;
+        is_atomic = SymbolicUtils.default_is_atomic,
+        kwargs...,
     )
-    return first(keys(s.arguments)).ops
+    for c in values(s.arguments)
+        Symbolics.get_variables!(
+            buffer, real(c), varlist; is_atomic = is_atomic, kwargs...
+        )
+        Symbolics.get_variables!(
+            buffer, imag(c), varlist; is_atomic = is_atomic, kwargs...
+        )
+    end
+    return buffer
 end

--- a/src/operators/operators.jl
+++ b/src/operators/operators.jl
@@ -22,7 +22,7 @@ julia> length(fundamental_operators(h))
 3
 ```
 
-See also [`find_operators`](@ref), [`unique_ops`](@ref).
+See also [`find_operators`](@ref), [`unique_up_to_adjoint`](@ref).
 """
 function fundamental_operators(h::FockSpace, si::Int = 1; names::Union{Nothing, AbstractVector} = nothing)
     name = names === nothing ? :a : names[si]
@@ -71,7 +71,7 @@ function fundamental_operators(h::ProductSpace; names::Union{Nothing, AbstractVe
 end
 
 """
-    unique_ops(ops) -> Vector
+    unique_up_to_adjoint(ops) -> Vector
 
 Return unique operators from `ops`, treating `op` and `op'` (adjoint) as the
 same degree of freedom. Only the first occurrence of each operator/adjoint pair
@@ -84,22 +84,22 @@ julia> h = FockSpace(:f);
 
 julia> @qnumbers a::Destroy(h);
 
-julia> length(unique_ops([a, a', a]))
+julia> length(unique_up_to_adjoint([a, a', a]))
 1
 ```
 
-See also [`unique_ops!`](@ref), [`fundamental_operators`](@ref).
+See also [`unique_up_to_adjoint!`](@ref), [`fundamental_operators`](@ref).
 """
-function unique_ops(ops::AbstractVector)
+function unique_up_to_adjoint(ops::AbstractVector{<:QField})
     ops_ = copy(ops)
-    unique_ops!(ops_)
+    unique_up_to_adjoint!(ops_)
     return ops_
 end
 
 """
-    unique_ops!(ops) -> Vector
+    unique_up_to_adjoint!(ops) -> Vector
 
-In-place version of [`unique_ops`](@ref).
+In-place version of [`unique_up_to_adjoint`](@ref).
 
 # Examples
 
@@ -110,13 +110,13 @@ julia> @qnumbers a::Destroy(h);
 
 julia> v = [a, a'];
 
-julia> SecondQuantizedAlgebra.unique_ops!(v);
+julia> SecondQuantizedAlgebra.unique_up_to_adjoint!(v);
 
 julia> length(v)
 1
 ```
 """
-function unique_ops!(ops::AbstractVector)
+function unique_up_to_adjoint!(ops::AbstractVector{<:QField})
     seen = Set{UInt}()
     j = 0
     for i in eachindex(ops)
@@ -155,7 +155,7 @@ julia> length(find_operators(h, 1))
 1
 ```
 
-See also [`fundamental_operators`](@ref), [`unique_ops`](@ref).
+See also [`fundamental_operators`](@ref), [`unique_up_to_adjoint`](@ref).
 """
 function find_operators(h::HilbertSpace, order::Int; names::Union{Nothing, AbstractVector} = nothing)
     # Auto-generate names when ProductSpace has duplicate space types
@@ -183,7 +183,7 @@ function find_operators(h::HilbertSpace, order::Int; names::Union{Nothing, Abstr
         end
     end
 
-    unique_ops!(all_ops)
+    unique_up_to_adjoint!(all_ops)
     return all_ops
 end
 
@@ -240,7 +240,7 @@ Hermitian conjugate of an operator expression. Method added to
 ecosystem) so it resolves without qualification when both are loaded. Forwards
 to [`qadjoint`](@ref); use `qadjoint`/`qconj` for bare scalar/symbolic adjoints.
 """
-dagger(x::QField) = qadjoint(x)
+QuantumInterface.dagger(x::QField) = qadjoint(x)
 
 """
     inner_adjoint(x)

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -15,9 +15,10 @@ for T in (Int, Float64, ComplexF64, Rational{Int}, Num)
     precompile(*, (T, Op))
     precompile(*, (Op, T))
 end
-# Public single-term accessors, not reached by the display-driven workload.
-precompile(prefactor, (QAdd,))
-precompile(operators, (QAdd,))
+# Public accessors not reached by the display-driven workload.
+precompile(get_prefactor, (QAdd,))
+precompile(get_operators, (QAdd,))
+precompile(get_variables, (QAdd,))
 precompile(to_num, (CNum,))
 
 # === Representative workload ===

--- a/test/fundamentals/indexing_test.jl
+++ b/test/fundamentals/indexing_test.jl
@@ -138,7 +138,7 @@ import SecondQuantizedAlgebra: constraint_pairs
 
         distinct = assume_distinct_index(ai * aj', [(i, j)])
         @test any(pair -> pair == (i, j) || pair == (j, i), constraint_pairs(distinct))
-        @test operators(distinct) == operators(ai * aj')
+        @test get_operators(distinct) == get_operators(ai * aj')
         @test !isequal(distinct, ai * aj')
 
         hproduct = hf ⊗ hn
@@ -210,7 +210,8 @@ import SecondQuantizedAlgebra: constraint_pairs
             pair -> pair == (i, j) || pair == (j, i),
             constraint_pairs(product_sum),
         )
-        @test haskey(product_sum, operators(adj * aj))
+        product_key = first(keys((adj * aj).arguments)).ops
+        @test haskey(product_sum, product_key)
 
         constrained = Σ(adj * ai, i, [j])
         @test length(constrained) == 1
@@ -296,7 +297,8 @@ import SecondQuantizedAlgebra: constraint_pairs
         σ(α, β, k) = IndexedOperator(Transition(h, :σ, α, β), k)
 
         double_sum = Σ(Σ(σ(2, 1, i) * σ(1, 2, j), i), j)
-        @test haskey(double_sum, operators(Σ(σ(2, 2, j), j)))
+        diagonal_key = first(keys(Σ(σ(2, 2, j), j).arguments)).ops
+        @test haskey(double_sum, diagonal_key)
         @test any(
             pair -> pair == (i, j) || pair == (j, i),
             constraint_pairs(double_sum),

--- a/test/fundamentals/operators_test.jl
+++ b/test/fundamentals/operators_test.jl
@@ -1,6 +1,6 @@
 using SecondQuantizedAlgebra
 using Test
-using Symbolics: @variables
+using Symbolics: Symbolics, @variables
 import SecondQuantizedAlgebra: OP_DESTROY, OP_PAULI, OP_TRANSITION, rename, set_acts_on
 
 @testset "Operator discovery and identity" begin
@@ -61,14 +61,43 @@ import SecondQuantizedAlgebra: OP_DESTROY, OP_PAULI, OP_TRANSITION, rename, set_
     @testset "adjoint-aware uniqueness" begin
         h = FockSpace(:cavity)
         a = Destroy(h, :a)
-        @test unique_ops([a, a']) == [a]
-        @test unique_ops([a', a]) == [a']
+        @test unique_up_to_adjoint([a, a']) == [a]
+        @test unique_up_to_adjoint([a', a]) == [a']
 
         hp = PauliSpace(:pauli)
         σx = Pauli(hp, :σ, 1)
         σy = Pauli(hp, :σ, 2)
-        @test unique_ops([σx, σx']) == [σx]
-        @test unique_ops([σx, σy]) == [σx, σy]
+        @test unique_up_to_adjoint([σx, σx']) == [σx]
+        @test unique_up_to_adjoint([σx, σy]) == [σx, σy]
+    end
+
+    @testset "QAdd introspection" begin
+        h = FockSpace(:cavity) ⊗ SpinSpace(:spin)
+        a = Destroy(h, :a, 1)
+        Sx = Spin(h, :S, 1, 2)
+        Sz = Spin(h, :S, 3, 2)
+        @variables ω₀ ωₐ g
+
+        H = ω₀ * a' * a + ωₐ * Sz + g * (a + a') * Sx
+        ops = get_operators(H)
+        @test eltype(ops) === Op
+        @test length(ops) == 4
+        @test ops == [a, a', Sx, Sz]
+        @test get_operators(a * a) == [a]
+
+        expected = Set(Symbolics.unwrap.([ω₀, ωₐ, g]))
+        @test Set(get_variables(H)) == expected
+        @test Set(Symbolics.get_variables(H)) == expected
+        @test Set(get_variables(H, [ω₀])) == Set([Symbolics.unwrap(ω₀)])
+        buffer = Set{Any}()
+        @test Symbolics.get_variables!(buffer, H) === buffer
+        @test buffer == expected
+        @test isempty(get_variables(2 * a))
+
+        i = Index(h, :i, 3, 1)
+        ai = IndexedOperator(a, i)
+        gi = IndexedVariable(:g, i)
+        @test sort(string.(get_variables(gi * ai))) == ["g", "i"]
     end
 
     @testset "operator products can be discovered" begin
@@ -169,8 +198,8 @@ end
         hs = SpinSpace(:s)
         hp = PauliSpace(:p)
         ops = [Destroy(FockSpace(:f), :a), Transition(NLevelSpace(:n, 2), :σ, 1, 2), Pauli(hp, :σ, 1), Spin(hs, :S, 1)]
-        @test length(unique_ops(ops)) == length(ops)
-        @test length(unique_ops([ops[1], ops[1]'])) == 1
+        @test length(unique_up_to_adjoint(ops)) == length(ops)
+        @test length(unique_up_to_adjoint([ops[1], ops[1]'])) == 1
 
         # Public auto-detect: single subspace of each type infers space_index
         h_mixed = FockSpace(:c) ⊗ NLevelSpace(:atom, 2) ⊗ PauliSpace(:p) ⊗

--- a/test/fundamentals/qadd_introspection_coverage_test.jl
+++ b/test/fundamentals/qadd_introspection_coverage_test.jl
@@ -1,0 +1,14 @@
+using Test
+using SecondQuantizedAlgebra
+using Symbolics: Symbolics, @variables
+
+@testset "filtered QAdd variable collection" begin
+    h = FockSpace(:cavity)
+    @qnumbers a::Destroy(h)
+    @variables x y
+
+    H = (x + im * y) * a + y * a'
+    buffer = Set{Any}()
+    @test Symbolics.get_variables!(buffer, H, [x, y]) === buffer
+    @test buffer == Set(Symbolics.unwrap.([x, y]))
+end

--- a/test/numeric/parameter_substitution_test.jl
+++ b/test/numeric/parameter_substitution_test.jl
@@ -1,5 +1,5 @@
 using SecondQuantizedAlgebra
-import SecondQuantizedAlgebra: QSym, prefactor
+import SecondQuantizedAlgebra: QSym, get_prefactor
 using QuantumOpticsBase
 using Symbolics: @variables, substitute
 using Test
@@ -40,7 +40,7 @@ dat(x) = dense(x).data
         @qnumbers a::Destroy(h)
         @variables x::Real
 
-        lowered = prefactor(x * a)
+        lowered = get_prefactor(x * a)
         @test isequal(real(lowered), x)
         @test iszero(imag(lowered))
     end

--- a/test/symbolic/coefficients_test.jl
+++ b/test/symbolic/coefficients_test.jl
@@ -7,7 +7,7 @@ using Test
     h = FockSpace(:coefficients)
     a = Destroy(h, :a)
 
-    coefficient(x) = prefactor(x * a)
+    coefficient(x) = get_prefactor(x * a)
     stored_coefficient(x) = only(x).second
 
     @testset "numeric and exact coefficients" begin
@@ -65,15 +65,15 @@ using Test
         distinct = [Num(k) * p[k] for k in 1:6]
         s = sum(distinct[k] * a for k in 1:6)
         @test length(s) == 1
-        @test occursin("p[1]", string(prefactor(s)))
-        @test occursin("p[6]", string(prefactor(s)))
+        @test occursin("p[1]", string(get_prefactor(s)))
+        @test occursin("p[6]", string(get_prefactor(s)))
         coalesced = g * a + 2g * a + 3g * a
         @test iszero(simplify(coalesced - 6g * a))
         @test length(coalesced) == 1
         different = g * a + κ * a
         @test length(different) == 1
-        @test occursin("g", string(prefactor(different)))
-        @test occursin("κ", string(prefactor(different)))
+        @test occursin("g", string(get_prefactor(different)))
+        @test occursin("κ", string(get_prefactor(different)))
         @test iszero(simplify(different - (g + κ) * a))
         product = (2g * a) * (3κ * a')
         @test iszero(simplify(product - 6 * g * κ * a * a'))

--- a/test/symbolic/phases_test.jl
+++ b/test/symbolic/phases_test.jl
@@ -93,7 +93,7 @@ import SecondQuantizedAlgebra: expim, exponential_form, phase_terms, to_num,
 
     @testset "public coefficient boundaries remain inferable" begin
         @variables ω t
-        @test prefactor(expim(ω * t) * a) isa Complex{Num}
+        @test get_prefactor(expim(ω * t) * a) isa Complex{Num}
         @inferred expim(ω * t)
         @inferred exponential_form(cos(ω * t))
         @inferred trigonometric_form(expim(ω * t))
@@ -123,7 +123,7 @@ import SecondQuantizedAlgebra: expim, exponential_form, phase_terms, to_num,
         trig = trigonometric_form(Complex(Num(z), Num(z)))
         @test iszero(simplify(trig * a - (z + im * z) * a))
         complex_coefficient = Complex(Num(z), Num(z)) * a
-        @test isequal(prefactor(complex_coefficient), Complex(Num(z), Num(z)))
+        @test isequal(get_prefactor(complex_coefficient), Complex(Num(z), Num(z)))
         @test isequal(
             exponential_form(Complex(Num(z), Num(z))),
             Complex(Num(z), Num(z)),


### PR DESCRIPTION
Closes #249.

This PR defines the public operator/variable introspection surface for algebra expressions:

- add `get_operators(::QAdd)`, collecting unique operators across all terms in canonical order;
- extend and re-export `Symbolics.get_variables` for `QAdd`, including filtered and buffer forms;
- rename the expression accessors to `get_prefactor`, `get_operators`, and `get_variables`;
- rename adjoint-aware deduplication from `unique_ops` to `unique_up_to_adjoint`;
- update precompile coverage, tests, API docs, changelog, and the package version for the breaking rename.

The branch is rebased onto current `main`. The older tensor-qualification changes from the original branch are intentionally not replayed: `main` now owns the TensorCore/QuantumInterface tensor fix and its regression tests.