### PR TITLE
Fix standalone Coeff LaTeX display

### DIFF
--- a/src/printing/latexify_recipes.jl
+++ b/src/printing/latexify_recipes.jl
@@ -94,6 +94,12 @@ function latex_prefactor(c::CNum)
 end
 latex_prefactor(c::Number) = c
 
+# Standalone coefficients use the same lowering as operator prefactors so their
+# representation tier remains an implementation detail of the coefficient algebra.
+@latexrecipe function f(c::Coeff)
+    return latex_prefactor(c)
+end
+
 const LATEX_TERM = Union{Expr, Number, SymbolicUtils.BasicSymbolic}
 const LATEX_FRAGMENT = Union{String, Symbol, QSym, Number, SymbolicUtils.BasicSymbolic}
 
@@ -250,3 +256,4 @@ end
 
 const QLaTeX = Union{<:QField}
 Base.show(io::IO, ::MIME"text/latex", x::QLaTeX) = write(io, latexify(x))
+Base.show(io::IO, ::MIME"text/latex", c::Coeff) = write(io, latexify(c))

--- a/test/presentation/coeff_latex_rendering_test.jl
+++ b/test/presentation/coeff_latex_rendering_test.jl
@@ -1,0 +1,24 @@
+using SecondQuantizedAlgebra
+using Latexify
+using LaTeXStrings
+using Symbolics: @variables
+using Test
+import SecondQuantizedAlgebra: expim, to_cnum
+
+@testset "Standalone Coeff LaTeX" begin
+    @variables g κ θ
+
+    cases = [
+        (to_cnum(2im), L"2\mathit{i}"),
+        (to_cnum(g), L"g"),
+        (to_cnum(im * g), L"g ~ \mathit{i}"),
+        (to_cnum(g + im * κ), L"g + \kappa ~ \mathit{i}"),
+        (expim(θ), L"e^{i \theta}"),
+    ]
+
+    for (c, expected) in cases
+        @test c isa SecondQuantizedAlgebra.Coeff
+        @test latexify(c) == expected
+        @test repr(MIME"text/latex"(), c) == expected
+    end
+end


### PR DESCRIPTION
## Summary

Add standalone LaTeX rendering for `Coeff` values.

`Coeff` already had ordinary `show` support, and coefficients embedded in operator expressions already passed through `latex_prefactor`. Standalone `latexify(c)` / `repr(MIME"text/latex"(), c)` did not participate in that presentation path because the MIME hook only covered `QField`.

This PR:

- adds a `Latexify` recipe for `Coeff` that reuses `latex_prefactor`;
- adds the `text/latex` MIME `show` method for standalone `Coeff` values;
- keeps `Native`, `Poly`, and `RawSymbolicCoeff` completely out of the printer;
- adds focused presentation regressions for native imaginary, real symbolic, symbolic imaginary, symbolic complex, and exact phase coefficients.

## Scope

Presentation-only. No changes to coefficient algebra, canonicalization, numeric lowering, or operator rendering.

## Tests

Added `test/presentation/coeff_latex_rendering_test.jl`, covering both `latexify(c)` and `repr(MIME"text/latex"(), c)` for representative coefficient forms.