### PR TITLE
ci: fix workflow path filters

### DIFF
--- a/.github/workflows/Benchmarks.yaml
+++ b/.github/workflows/Benchmarks.yaml
@@ -4,19 +4,17 @@ on:
     branches:
       - 'main'
     paths:
-      - '.github/workflows/Tests.yml'
+      - '.github/workflows/Benchmarks.yaml'
       - 'src/**'
       - 'ext/**'
+      - 'test/**'
       - 'benchmark/**'
-      - 'test/runtests.jl'
-      - 'test/core-test/**'
-      - 'test/ext-test/cpu/**'
       - 'Project.toml'
   pull_request:
     branches:
       - 'main'
     paths:
-      - '.github/workflows/Tests.yml'
+      - '.github/workflows/Benchmarks.yaml'
       - 'src/**'
       - 'ext/**'
       - 'test/**'

--- a/.github/workflows/Format.yml
+++ b/.github/workflows/Format.yml
@@ -4,13 +4,13 @@ on:
     branches:
       - 'main'
     paths:
-      - '.github/workflows/FormatCheck.yml'
+      - '.github/workflows/Format.yml'
       - '**.jl'
   pull_request:
     branches:
       - 'main'
     paths:
-      - '.github/workflows/FormatCheck.yml'
+      - '.github/workflows/Format.yml'
       - '**.jl'
     types:
       - opened


### PR DESCRIPTION
## Summary

Fix stale/mistyped GitHub Actions path filters found while auditing the Julia 1.13/JET CI failure in #259.

- `Format.yml` now watches its actual workflow file instead of the nonexistent `FormatCheck.yml`.
- `Benchmarks.yaml` now watches itself instead of `Tests.yml`.
- benchmark push filtering now uses the current `test/**` tree, matching the pull-request filter, instead of obsolete `test/core-test/**` and `test/ext-test/cpu/**` paths.

These changes make edits to the workflows self-trigger correctly and ensure benchmark-relevant test changes on `main` are not silently missed.

No package source, tests, benchmark definitions, or runtime behavior changes.