### PR TITLE
ci: test the minimum supported Julia explicitly

### DIFF
--- a/.github/workflows/JET.yml
+++ b/.github/workflows/JET.yml
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.13'
+          - '1'
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 'lts'
+          - 'min'
           - '1.13'
         os:
           - ubuntu-latest
@@ -69,11 +69,11 @@ jobs:
         with:
           name: coverage-lcov
           path: lcov.info
-        if: ${{ matrix.version == 'lts' }}
+        if: ${{ matrix.version == 'min' }}
       - uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: lcov.info
           name: codecov-umbrella
           fail_ci_if_error: false
-        if: ${{ matrix.version == 'lts' }}
+        if: ${{ matrix.version == 'min' }}

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -73,7 +73,7 @@ jobs:
       - uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: lcov.info
+          files: lcov.info
           name: codecov-umbrella
           fail_ci_if_error: false
         if: ${{ matrix.version == 'min' }}

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         version:
           - 'min'
-          - '1.13'
+          - '1'
         os:
           - ubuntu-latest
         arch:


### PR DESCRIPTION
## Summary

Make the main test matrix express SQA's support boundaries directly while preserving the moving current-stable Julia lane.

`Project.toml` declares `julia = "1.10"`. The workflow currently uses `lts` as a proxy for that lower bound; today that happens to resolve to Julia 1.10, but the alias can move independently of SQA's declared compatibility.

This PR:

- replaces the `lts` test job with `min`, which `setup-julia@v3` resolves from the project's Julia compat;
- restores the current-stable test and JET lanes to the moving Julia `1` selector instead of pinning them to `1.13`;
- moves coverage upload/Codecov to the `min` job;
- fixes the Codecov v7 configuration from the ignored `file:` input to the supported `files:` input.

This yields two clear CI roles: oldest supported Julia and current stable Julia. The `1` selector currently resolves to Julia 1.13 and will continue tracking future Julia 1.x releases automatically.

## Validation

The first `min` run resolved to Julia 1.10.12 and passed the full SQA suite (3069/3069). That run also exposed the stale Codecov input key, which this PR corrects and revalidates.