### PR TITLE
ci: validate QuantumCumulants SQA 0.12 migration

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -52,26 +52,39 @@ jobs:
           version: ${{ matrix.julia-version }}
           arch: x64
       - uses: julia-actions/cache@v3
-      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-buildpkg@v1
       - name: Clone Downstream
         uses: actions/checkout@v7
         with:
           repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
           path: downstream
       - name: Load this and run the downstream tests
-        shell: julia --color=yes --project=downstream --depwarn=yes {0}
+        shell: julia --color=yes --project=@. --depwarn=yes {0}
         run: |
           using Pkg
-          try
-            # force it to use this PR's version of the package
-            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
-            Pkg.update()
-            Pkg.test(coverage=true)  # resolver may fail with test time deps
-          catch err
-            err isa Pkg.Resolve.ResolverError || rethrow()
-            # If we can't resolve that means this is incompatible by SemVer and this is fine
-            # It means we marked this as a breaking change, so we don't need to worry about
-            # Mistakenly introducing a breaking change, as we have intentionally made one
-            @info "Not compatible with this release. No problem." exception=err
-            exit(0)  # Exit immediately, as a success
+          using TOML
+
+          # Downstream releases may not yet declare compatibility with this development
+          # version of SQA. Remove only that bound in the temporary CI clone so this job
+          # tests the downstream code against the checkout under review. All other compat
+          # constraints remain intact and any resolver or test failure is a real failure.
+          function relax_sqa_compat(project_file)
+            isfile(project_file) || return
+            project = TOML.parsefile(project_file)
+            compat = get(project, "compat", nothing)
+            compat isa AbstractDict || return
+            previous = pop!(compat, "SecondQuantizedAlgebra", nothing)
+            previous === nothing && return
+            @info "Temporarily removing downstream SQA compat" project_file previous
+            open(project_file, "w") do io
+              TOML.print(io, project)
+            end
           end
+
+          relax_sqa_compat(joinpath("downstream", "Project.toml"))
+          relax_sqa_compat(joinpath("downstream", "test", "Project.toml"))
+
+          Pkg.activate("downstream")
+          Pkg.develop(PackageSpec(path=pwd()))
+          Pkg.update()
+          Pkg.test(coverage=true)

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -65,24 +65,28 @@ jobs:
           using TOML
 
           # Downstream releases may not yet declare compatibility with this development
-          # version of SQA. Remove only that bound in the temporary CI clone so this job
-          # tests the downstream code against the checkout under review. All other compat
-          # constraints remain intact and any resolver or test failure is a real failure.
-          function relax_sqa_compat(project_file)
+          # version of SQA. Pin only that bound to the checkout's exact package version in
+          # the temporary CI clone. This lets Pkg resolve the checkout under review while
+          # preserving valid package metadata for downstream checks such as Aqua.
+          sqa_version = VersionNumber(TOML.parsefile("Project.toml")["version"])
+          sqa_compat = "=" * string(sqa_version)
+
+          function pin_sqa_compat(project_file, compat_spec)
             isfile(project_file) || return
             project = TOML.parsefile(project_file)
             compat = get(project, "compat", nothing)
             compat isa AbstractDict || return
-            previous = pop!(compat, "SecondQuantizedAlgebra", nothing)
+            previous = get(compat, "SecondQuantizedAlgebra", nothing)
             previous === nothing && return
-            @info "Temporarily removing downstream SQA compat" project_file previous
+            compat["SecondQuantizedAlgebra"] = compat_spec
+            @info "Temporarily pinning downstream SQA compat to checkout version" project_file previous compat_spec
             open(project_file, "w") do io
               TOML.print(io, project)
             end
           end
 
-          relax_sqa_compat(joinpath("downstream", "Project.toml"))
-          relax_sqa_compat(joinpath("downstream", "test", "Project.toml"))
+          pin_sqa_compat(joinpath("downstream", "Project.toml"), sqa_compat)
+          pin_sqa_compat(joinpath("downstream", "test", "Project.toml"), sqa_compat)
 
           Pkg.activate("downstream")
           Pkg.develop(PackageSpec(path=pwd()))

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -28,22 +28,16 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.package.repo }}/${{ matrix.julia-version }}
+    name: QuantumCumulants.jl/${{ matrix.julia-version }}
     runs-on: ${{ matrix.os }}
     permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
       actions: write
       contents: read
-    env:
-      GROUP: ${{ matrix.package.group }}
     strategy:
       fail-fast: false
       matrix:
         julia-version: ['1']
         os: [ubuntu-latest]
-        package:
-          - {user: qojulia, repo: QuantumCumulants.jl}
-          - {user: qojulia, repo: QuantumInputOutput.jl}
-          - {user: oameye, repo: FloquetExpansions.jl}
 
     steps:
       - uses: actions/checkout@v7
@@ -53,10 +47,11 @@ jobs:
           arch: x64
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
-      - name: Clone Downstream
+      - name: Clone QuantumCumulants migration branch
         uses: actions/checkout@v7
         with:
-          repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
+          repository: qojulia/QuantumCumulants.jl
+          ref: compat/sqa-0.12
           path: downstream
       - name: Load this and run the downstream tests
         shell: julia --color=yes --project=@. --depwarn=yes {0}
@@ -64,10 +59,6 @@ jobs:
           using Pkg
           using TOML
 
-          # Downstream releases may not yet declare compatibility with this development
-          # version of SQA. Pin only that bound to the checkout's exact package version in
-          # the temporary CI clone. This lets Pkg resolve the checkout under review while
-          # preserving valid package metadata for downstream checks such as Aqua.
           sqa_version = VersionNumber(TOML.parsefile("Project.toml")["version"])
           sqa_compat = "=" * string(sqa_version)
 
@@ -79,7 +70,6 @@ jobs:
             previous = get(compat, "SecondQuantizedAlgebra", nothing)
             previous === nothing && return
             compat["SecondQuantizedAlgebra"] = compat_spec
-            @info "Temporarily pinning downstream SQA compat to checkout version" project_file previous compat_spec
             open(project_file, "w") do io
               TOML.print(io, project)
             end


### PR DESCRIPTION
Temporary cross-repository validation for qojulia/QuantumCumulants.jl#358.

This branch is based on #264's corrected downstream harness but points the QuantumCumulants checkout at `compat/sqa-0.12`. It exists only to run the full QC suite against the local SQA 0.12 checkout before SQA 0.12 is available from General.

Do not merge; close after validation.