### PR TITLE
test: preserve squeezing commutator cancellation regression

### DIFF
--- a/test/algebra/squeezing_commutator_regression_test.jl
+++ b/test/algebra/squeezing_commutator_regression_test.jl
@@ -1,0 +1,16 @@
+using SecondQuantizedAlgebra
+using Symbolics: @variables
+using Test
+
+@testset "Squeezing commutator cancels exact rational coefficients" begin
+    h = FockSpace(:cavity)
+    a = Destroy(h, :a)
+    @variables Δ λ
+
+    H = Δ * a' * a + (λ / 2) * (a' * a' + a * a)
+    rhs = commutator(im * H, a * a)
+    expected = -2im * Δ * a * a - im * λ * (2 * a' * a + 1)
+
+    # Exact public-API equality: this must fail if a zero-coefficient fourth-order term survives.
+    @test iszero(rhs - expected)
+end


### PR DESCRIPTION
## Summary

Port the physically relevant regression from #167 onto the current coefficient architecture using only public API.

The test constructs the quadratic squeezing Hamiltonian

```julia
H = Δ * a' * a + (λ / 2) * (a' * a' + a * a)
```

and verifies directly that

```julia
commutator(im * H, a * a)
```

matches the exact quadratic result. The assertion deliberately does **not** call `simplify`, inspect internal terms, or use private coefficient helpers, so it catches any future regression where a mathematically zero fourth-order contribution survives in the canonical `QAdd`.

No production code changes. #167 is superseded because the current `Coeff` recognizer already canonicalizes integer division to exact rational multiplication at coefficient construction time.